### PR TITLE
Version bump to coredns 1.8.1

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: coredns
-version: 1.14.0
-appVersion: 1.8.0
+version: 1.14.1
+appVersion: 1.8.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services

--- a/stable/coredns/README.md
+++ b/stable/coredns/README.md
@@ -47,7 +47,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Parameter                               | Description                                                                           | Default                                                     |
 |:----------------------------------------|:--------------------------------------------------------------------------------------|:------------------------------------------------------------|
 | `image.repository`                      | The image repository to pull from                                                     | coredns/coredns                                             |
-| `image.tag`                             | The image tag to pull from                                                            | `v1.7.1`                                                    |
+| `image.tag`                             | The image tag to pull from                                                            | `v1.8.1`                                                    |
 | `image.pullPolicy`                      | Image pull policy                                                                     | IfNotPresent                                                |
 | `replicaCount`                          | Number of replicas                                                                    | 1                                                           |
 | `resources.limits.cpu`                  | Container maximum CPU                                                                 | `100m`                                                      |

--- a/stable/coredns/templates/configmap.yaml
+++ b/stable/coredns/templates/configmap.yaml
@@ -12,6 +12,9 @@ metadata:
     kubernetes.io/name: "CoreDNS"
     {{- end }}
     app.kubernetes.io/name: {{ template "coredns.name" . }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
 data:
   Corefile: |-
     {{ range .Values.servers }}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: coredns/coredns
-  tag: "1.8.0"
+  tag: "1.8.1"
   pullPolicy: IfNotPresent
 
 replicaCount: 1


### PR DESCRIPTION
@haad version bump to coredns-1.8.1 https://github.com/coredns/coredns/releases/tag/v1.8.1 https://coredns.io/2021/01/20/coredns-1.8.1-release/