### PR TITLE
Add support for ServiceAccount annotations

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.14.0
+version: 1.14.1
 appVersion: 1.8.0
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -39,9 +39,9 @@ spec:
         {{- end }}
         app.kubernetes.io/name: {{ template "coredns.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        {{- if .Values.customLabels }}
-        {{ toYaml .Values.customLabels }}
-        {{- end }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 8 }}
+{{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.isClusterService }}

--- a/stable/coredns/templates/serviceaccount.yaml
+++ b/stable/coredns/templates/serviceaccount.yaml
@@ -13,4 +13,8 @@ metadata:
     kubernetes.io/name: "CoreDNS"
     {{- end }}
     app.kubernetes.io/name: {{ template "coredns.name" . }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -70,6 +70,7 @@ serviceAccount:
   # The name of the ServiceAccount to use
   # If not set and create is true, a name is generated using the fullname template
   name:
+  annotations: {}
 
 rbac:
   # If true, create & use RBAC resources


### PR DESCRIPTION
This PR adds support for passing ServiceAccount annotations, which is required for example to deploy CoreDNS on AWS EKS with IAM Role ARN in annotations.

Furthermore, this PR also fixes #3.