### PR TITLE
chore: fix release path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,6 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0
         with:
-          charts_dir: stable/
+          charts_dir: stable
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The path to charts is wrong, so the chart-releaser looks to wrong folder.

I've stripped the last slash, so chart releaser is now checking the right folder.

fixes #16

https://github.com/helm/chart-releaser-action/blob/120944e66390c2534cc1b3c62d7285ba7ff02594/cr.sh#L228