### PR TITLE
Allow to skip ConfigMap creation

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.15.0
+version: 1.15.1
 appVersion: 1.8.0
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png

--- a/stable/coredns/README.md
+++ b/stable/coredns/README.md
@@ -113,6 +113,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `autoscaler.configmap.annotations`      | Annotations to add to autoscaler config map. For example to stop CI renaming them                                                         | {}                                                          |
 | `deployment.enabled`                    | Optionally disable the main deployment and its respective resources.                                                                      | `true`                                                      |
 | `deployment.name`                       | Name of the deployment if `deployment.enabled` is true. Otherwise the name of an existing deployment for the autoscaler or HPA to target. | `""`                                                        |
+| `deployment.skipConfig`                 | Optionally disable config map generation.                                                                                                 | `false`                                                     |
 
 See `values.yaml` for configuration notes. Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/coredns/templates/configmap.yaml
+++ b/stable/coredns/templates/configmap.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.deployment.enabled }}
+{{- if .Values.deployment.enabled  }}
+{{- if not .Values.deployment.skipConfig }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -33,4 +34,5 @@ data:
   {{- range .Values.zoneFiles }}
   {{ .filename }}: {{ toYaml .contents | indent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -276,5 +276,6 @@ autoscaler:
     annotations: {}
 
 deployment:
+  skipConfig: false
   enabled: true
   name: ""


### PR DESCRIPTION
There are cases where zones are different but plugins are. In order to
avoid duplication of whole zone block configuration, allow to disable
config map creation and let it to be managable externally, where it is
possible to keep plugins configuration same, but change zone definition
only.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>