### PR TITLE
Fix default ports for dns:// scheme

### DIFF
--- a/charts/coredns/templates/_helpers.tpl
+++ b/charts/coredns/templates/_helpers.tpl
@@ -57,10 +57,9 @@ Generate the list of ports automatically from the server definitions
             {{- end -}}
         {{- end -}}
 
-        {{/* If none of the zones specify scheme, default to dns:// on both tcp & udp */}}
+        {{/* If none of the zones specify scheme, default to dns:// udp */}}
         {{- if and (not (index $innerdict "istcp")) (not (index $innerdict "isudp")) -}}
             {{- $innerdict := set $innerdict "isudp" true -}}
-            {{- $innerdict := set $innerdict "istcp" true -}}
         {{- end -}}
 
         {{/* Write the dict back into the outer dict */}}


### PR DESCRIPTION
According to [values.yaml](https://github.com/coredns/helm/blob/master/stable/coredns/values.yaml#L130)
dns:// is supposed to be udp only with optional tcp enablement through
use_tcp flag.

Signed-off-by: Dinar Valeev <k0da@opensuse.org>