### PR TITLE
Bump HPA to autoscaling/v2beta2

### DIFF
--- a/stable/coredns/templates/hpa.yaml
+++ b/stable/coredns/templates/hpa.yaml
@@ -1,6 +1,6 @@
 {{- if and (.Values.hpa.enabled) (not .Values.autoscaler.enabled) }}
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "coredns.fullname" . }}
@@ -26,4 +26,8 @@ spec:
   maxReplicas: {{ .Values.hpa.maxReplicas }}
   metrics:
 {{ toYaml .Values.hpa.metrics | indent 4 }}
+{{- if .Values.hpa.behavior }}
+  behavior:
+{{ toYaml .Values.hpa.behavior | indent 4 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
This commit bumps the apiVersion of HorizontalPodAutoscaler to autoscaling/v2beta2

autoscaling/v2beta1 has been deprecated since 1.12 I believe, with it
disappearing in 1.20.

Additionally, v2beta2 adds `spec.behavior`, so allowing people to
template it if needed.

Signed-off-by: Devon Mizelle <devon.mizelle@onepeloton.com>