### PR TITLE
Allow to skip ConfigMap creation

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.16.3
+version: 1.16.4
 appVersion: 1.8.4
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png

--- a/charts/coredns/templates/configmap.yaml
+++ b/charts/coredns/templates/configmap.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.deployment.enabled }}
+{{- if .Values.deployment.enabled  }}
+{{- if not .Values.deployment.skipConfig }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -33,4 +34,5 @@ data:
   {{- range .Values.zoneFiles }}
   {{ .filename }}: {{ toYaml .contents | indent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -297,5 +297,6 @@ autoscaler:
     successThreshold: 1
 
 deployment:
+  skipConfig: false
   enabled: true
   name: ""


### PR DESCRIPTION
There are cases where zones are different but plugins are. In order to
avoid duplication of whole zone block configuration, allow to disable
config map creation and let it to be managable externally, where it is
possible to keep plugins configuration same, but change zone definition
only.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>