### PR TITLE
service: add support nodePort for service ports

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.16.3
+version: 1.16.4
 appVersion: 1.8.4
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png

--- a/charts/coredns/templates/_helpers.tpl
+++ b/charts/coredns/templates/_helpers.tpl
@@ -63,17 +63,30 @@ Generate the list of ports automatically from the server definitions
             {{- $innerdict := set $innerdict "istcp" true -}}
         {{- end -}}
 
+        {{- if .nodePort -}}
+            {{- $innerdict := set $innerdict "nodePort" .nodePort -}}
+        {{- end -}}
+
         {{/* Write the dict back into the outer dict */}}
         {{- $ports := set $ports $port $innerdict -}}
     {{- end -}}
 
     {{/* Write out the ports according to the info collected above */}}
     {{- range $port, $innerdict := $ports -}}
+        {{- $portList := list -}}
         {{- if index $innerdict "isudp" -}}
-            {{- printf "- {port: %v, protocol: UDP, name: udp-%s}\n" $port $port -}}
+            {{- $portList = append $portList (dict "port" ($port | int) "protocol" "UDP" "name" (printf "udp-%s" $port)) -}}
         {{- end -}}
         {{- if index $innerdict "istcp" -}}
-            {{- printf "- {port: %v, protocol: TCP, name: tcp-%s}\n" $port $port -}}
+            {{- $portList = append $portList (dict "port" ($port | int) "protocol" "TCP" "name" (printf "tcp-%s" $port)) -}}
+        {{- end -}}
+
+        {{- range $portDict := $portList -}}
+            {{- if index $innerdict "nodePort" -}}
+                {{- $portDict := set $portDict "nodePort" (get $innerdict "nodePort" | int) -}}
+            {{- end -}}
+
+            {{- printf "- %s\n" (toJson $portDict) -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -102,6 +102,8 @@ servers:
 - zones:
   - zone: .
   port: 53
+  # If serviceType is nodePort you can specify nodePort here
+  # nodePort: 30053
   plugins:
   - name: errors
   # Serves a /health endpoint on :8080, required for livenessProbe


### PR DESCRIPTION
This will add support to specify nodePort when serviceType is nodePort

Signed-off-by: Seena Fallah <seenafallah@gmail.com>
Signed-off-by: Yasin Lachini <yasin.lachiny@gmail.com>