### PR TITLE
Allow to add extra config to the default Corefile

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.16.3
+version: 1.16.4
 appVersion: 1.8.4
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png

--- a/charts/coredns/templates/configmap.yaml
+++ b/charts/coredns/templates/configmap.yaml
@@ -19,6 +19,9 @@ metadata:
 {{- end }}
 data:
   Corefile: |-
+    {{- range $name, $conf := .Values.extraConfig }}
+    {{ $name }}{{ if $conf.parameters }} {{ $conf.parameters }}{{ end }}
+    {{- end }}
     {{ range .Values.servers }}
     {{- range $idx, $zone := .zones }}{{ if $idx }} {{ else }}{{ end }}{{ default "" $zone.scheme }}{{ default "." $zone.zone }}{{ else }}.{{ end -}}
     {{- if .port }}:{{ .port }} {{ end -}}

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -144,6 +144,13 @@ servers:
 #       hello world
 #       foo bar
 
+# Extra configuration that is applied outside of the default zone block.
+# Example to include additional config files, which may come from extraVolumes:
+# extraConfig:
+#   import:
+#     parameters: /opt/coredns/*.conf
+extraConfig: {}
+
 # To use the livenessProbe, the health plugin needs to be enabled in CoreDNS' server config
 livenessProbe:
   enabled: true


### PR DESCRIPTION
With this change it is possible to extra/custom config options
outside of the zones block which enables some further/advanced
customization.