### PR TITLE
Fix annotations generating invalid yaml

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.19.0
+version: 1.19.1
 appVersion: 1.9.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png

--- a/charts/coredns/templates/configmap-autoscaler.yaml
+++ b/charts/coredns/templates/configmap-autoscaler.yaml
@@ -18,11 +18,15 @@ metadata:
     {{- if .Values.customLabels }}
     {{- toYaml .Values.customLabels | nindent 4 }}
     {{- end }}
-{{ if or .Values.autoscaler.configmap.annotations .Values.customAnnotations }}
+  {{- if or .Values.autoscaler.configmap.annotations .Values.customAnnotations }}
   annotations:
-{{ toYaml .Values.customAnnotations | indent 4 }}
-{{- toYaml .Values.autoscaler.configmap.annotations | nindent 4 }}
-{{- end }}
+    {{- if .Values.customAnnotations }}
+    {{- toYaml .Values.customAnnotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.autoscaler.configmap.annotations -}}
+    {{ toYaml .Values.autoscaler.configmap.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
 data:
   # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
   # If using small nodes, "nodesPerReplica" should dominate.

--- a/charts/coredns/templates/deployment.yaml
+++ b/charts/coredns/templates/deployment.yaml
@@ -18,11 +18,15 @@ metadata:
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}
-{{ if or .Values.deployment.annotations .Values.customAnnotations }}
+  {{- if or .Values.deployment.annotations .Values.customAnnotations }}
   annotations:
-{{ toYaml .Values.customAnnotations | indent 4 }}
-{{ toYaml .Values.deployment.annotations | indent 4 }}
-{{- end }}
+    {{- if .Values.customAnnotations }}
+    {{- toYaml .Values.customAnnotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.deployment.annotations }}
+    {{- toYaml .Values.deployment.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaler.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/coredns/templates/service-metrics.yaml
+++ b/charts/coredns/templates/service-metrics.yaml
@@ -17,11 +17,17 @@ metadata:
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}
+{{- if or .Values.prometheus.service.annotations .Values.service.annotations .Values.customAnnotations }}
   annotations:
+{{- if .Values.prometheus.service.annotations }}
 {{ toYaml .Values.prometheus.service.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.service.annotations }}
 {{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 {{- if .Values.customAnnotations }}
 {{ toYaml .Values.customAnnotations | indent 4 }}
+{{- end }}
 {{- end }}
 spec:
   selector:

--- a/charts/coredns/templates/service-metrics.yaml
+++ b/charts/coredns/templates/service-metrics.yaml
@@ -17,18 +17,18 @@ metadata:
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}
-{{- if or .Values.prometheus.service.annotations .Values.service.annotations .Values.customAnnotations }}
+  {{- if or .Values.prometheus.service.annotations .Values.service.annotations .Values.customAnnotations }}
   annotations:
-{{- if .Values.prometheus.service.annotations }}
-{{ toYaml .Values.prometheus.service.annotations | indent 4 }}
-{{- end }}
-{{- if .Values.service.annotations }}
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
-{{- if .Values.customAnnotations }}
-{{ toYaml .Values.customAnnotations | indent 4 }}
-{{- end }}
-{{- end }}
+    {{- if .Values.prometheus.service.annotations }}
+    {{- toYaml .Values.prometheus.service.annotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.service.annotations }}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.customAnnotations }}
+    {{- toYaml .Values.customAnnotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   selector:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/charts/coredns/templates/service.yaml
+++ b/charts/coredns/templates/service.yaml
@@ -17,11 +17,15 @@ metadata:
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}
+  {{- if or .Values.service.annotations .Values.customAnnotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- if .Values.customAnnotations }}
-{{ toYaml .Values.customAnnotations | indent 4 }}
-{{- end }}
+    {{- if .Values.service.annotations }}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.customAnnotations }}
+    {{- toYaml .Values.customAnnotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   selector:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/charts/coredns/templates/serviceaccount.yaml
+++ b/charts/coredns/templates/serviceaccount.yaml
@@ -13,11 +13,15 @@ metadata:
     kubernetes.io/name: "CoreDNS"
     {{- end }}
     app.kubernetes.io/name: {{ template "coredns.name" . }}
-{{ if or .Values.serviceAccount.annotations .Values.customAnnotations }}
+  {{- if or .Values.serviceAccount.annotations .Values.customAnnotations }}
   annotations:
-{{ toYaml .Values.customAnnotations | indent 4 }}
-{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
-{{- end }}
+    {{- if .Values.customAnnotations }}
+    {{- toYaml .Values.customAnnotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
 {{- if .Values.image.pullSecrets }}
 imagePullSecrets:
 {{- range .Values.image.pullSecrets }}


### PR DESCRIPTION
It was easy to result in an invalid yaml error if you set some values. For example:  if you only set `prometheus.service.enabled` to `true` the yaml in service-metrics.yaml is invalid, or if you set something in `customAnnotations` many files could result in invalid yaml.

fix #60 