### PR TITLE
Helm second configuration rendering is supported. Variables can be fi…

### DIFF
--- a/charts/coredns/templates/configmap.yaml
+++ b/charts/coredns/templates/configmap.yaml
@@ -31,13 +31,13 @@ data:
     {{- if .port }}:{{ .port }} {{ end -}}
     {
       {{- range .plugins }}
-        {{ .name }}{{ if .parameters }} {{ .parameters }}{{ end }}{{ if .configBlock }} {
+        {{ .name }}{{ if .parameters }} {{ tpl (.parameters) $ }}{{ end }}{{ if .configBlock }} {
 {{ .configBlock | indent 12 }}
         }{{ end }}
       {{- end }}
     }
     {{ end }}
   {{- range .Values.zoneFiles }}
-  {{ .filename }}: {{ toYaml .contents | indent 4 }}
+  {{ .filename }}: {{ tpl (toYaml .contents | indent 4) $ }}
   {{- end }}
 {{- end }}

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -39,7 +39,7 @@ resources:
 #       targetAverageUtilization: 60
 
 rollingUpdate:
-  maxUnavailable: 1
+  maxUnavailable: 25%
   maxSurge: 25%
 
 # Under heavy load it takes more that standard time to remove Pod endpoint from a cluster.
@@ -126,7 +126,7 @@ servers:
   - name: forward
     parameters: . /etc/resolv.conf
   - name: cache
-    parameters: 30
+    parameters: "30"
   - name: loop
   - name: reload
   - name: loadbalance


### PR DESCRIPTION
Helm second configuration rendering is supported. Variables can be filled in zonefile configuration without the need for specific values.  

global:
  private_domain: www.test.com

example:

    - name: file 
      parameters: /etc/coredns/customdns.db {{ .Values.global.private_domain }} example.com



  zoneFiles:
   - filename: customdns.db
     contents: |
       @.   IN SOA sns.dns.icann.com. noc.dns.icann.com. 2015082541 7200 3600 1209600 3600
       example.com.   IN A   192.168.99.102
       *.example.com. IN A   192.168.99.102
       minio.hamish.com. IN CNAME  minio.test.svc.cluster.local.
       *.{{ .Values.global.private_domain }}. IN CNAME  nginx.test.svc.cluster.local.