### PR TITLE
Fix link to values.yaml

### DIFF
--- a/charts/coredns/README.md
+++ b/charts/coredns/README.md
@@ -154,7 +154,7 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 $ helm install coredns coredns/coredns -f values.yaml
 ```
 
-> **Tip**: You can use the default [values.yaml](values.yaml)
+> **Tip**: You can use the default [values.yaml](/charts/coredns/values.yaml)
 
 
 ## Caveats


### PR DESCRIPTION
Because README.md in the repository root is a symbolic link to charts/coredns/README.md, relative links to other files in the repository won't work.
This change makes the "Tip"-link absolute.