### PR TITLE
Add prometheus port to the container, Fixes #46

### DIFF
--- a/charts/coredns/templates/_helpers.tpl
+++ b/charts/coredns/templates/_helpers.tpl
@@ -137,6 +137,16 @@ Generate the list of ports automatically from the server definitions
 
         {{/* Write the dict back into the outer dict */}}
         {{- $ports := set $ports $port $innerdict -}}
+
+        {{/* Fetch port from the configuration if the prometheus section exists */}}
+        {{- range .plugins -}}
+            {{- if eq .name "prometheus" -}}
+                {{- $prometheus_addr := toString .parameters -}}
+                {{- $prometheus_addr_list := regexSplit ":" $prometheus_addr -1 -}}
+                {{- $prometheus_port := index $prometheus_addr_list 1 -}}
+                {{- $ports := set $ports $prometheus_port (dict "istcp" true "isudp" false) -}}
+            {{- end -}}
+        {{- end -}}
     {{- end -}}
 
     {{/* Write out the ports according to the info collected above */}}


### PR DESCRIPTION
This automatically creates an additional container port if prometheus has been defined inside the plugins section.
Containers should export all ports if they are used. We found this issue with https://github.com/derailed/popeye