### PR TITLE
Defalt val. of hpa.metrics to the correct type

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.19.4
+version: 1.19.5
 appVersion: 1.9.3
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -240,7 +240,7 @@ hpa:
   enabled: false
   minReplicas: 1
   maxReplicas: 2
-  metrics: {}
+  metrics: []
 
 ## Configue a cluster-proportional-autoscaler for coredns
 # See https://github.com/kubernetes-incubator/cluster-proportional-autoscaler


### PR DESCRIPTION
This sets the hpa.metrics key to its correct default value. Which is an array and not a dict. Having it as a dict. gives issues as seen in #79. Which I hope to solve with this PR.

See: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/#HorizontalPodAutoscalerSpec for the official ref. docs on HPA and the `metrics` key type specifically.

Thank you.