### PR TITLE
fix: externalIPs indentation

### DIFF
--- a/charts/coredns/templates/service.yaml
+++ b/charts/coredns/templates/service.yaml
@@ -38,7 +38,7 @@ spec:
   {{- end }}
   {{- if .Values.service.externalIPs }}
   externalIPs:
-  {{ toYaml .Values.service.externalIPs | indent 4 }}
+  {{- toYaml .Values.service.externalIPs | nindent 4 }}
   {{- end }}
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}


### PR DESCRIPTION
When using `services.externalIPs`, the service template isn't rendered correctly.

```yaml
spec:
  {{- if .Values.service.externalIPs }}
  externalIPs:
  {{ toYaml .Values.service.externalIPs | indent 4 }}
  {{- end }}
```

Given the following `values.yaml` :
```yaml
services:
  externalIPs:
    - 1.2.3.4
    - 2.3.4.5
```

The template will render as such :

```yaml
spec:
  externalIPs:
      - 1.2.3.4
    - 2.3.4.5
```

This comes from the fact that `indent` doesn't remove leading spaces for the first rendered line.

Proposed solution removes leading whitespace (including newlines) by using the left chomping modifier, and uses `nindent` to render a 4-space indented list prepended by a newline.