### PR TITLE
Add chart options for pod dnsConfig and dnsPolicy

### DIFF
--- a/charts/coredns/templates/deployment.yaml
+++ b/charts/coredns/templates/deployment.yaml
@@ -144,6 +144,13 @@ spec:
         securityContext:
 {{- toYaml .Values.securityContext | nindent 10 }}
 {{- end }}
+{{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+{{- end }}
+{{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | nindent 8 }}
+{{- end }}
       volumes:
         - name: config-volume
           configMap:

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -199,6 +199,12 @@ topologySpreadConstraints: []
 # Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
 
+# Configure pod DNS policy and config.
+# dnsPolicy: None
+# dnsConfig:
+#   nameservers:
+#     - 8.8.8.8
+
 # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
 # for example:
 #   tolerations:


### PR DESCRIPTION
This branch adds `dnsConfig` and `dnsPolicy` options to the chart, which allow the installer to override those options for the pod.