### PR TITLE
add support for environment variables

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.19.10
+version: 1.20.0
 appVersion: 1.9.4
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png

--- a/charts/coredns/README.md
+++ b/charts/coredns/README.md
@@ -137,6 +137,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `deployment.enabled`                           | Optionally disable the main deployment and its respective resources.                                                                      | `true`                                                       |
 | `deployment.name`                              | Name of the deployment if `deployment.enabled` is true. Otherwise the name of an existing deployment for the autoscaler or HPA to target. | `""`                                                         |
 | `deployment.annotations`                       | Annotations to add to the main deployment                                                                                                 | `{}`                                                         |
+| `deployment.env`                               | Environment variables to add to the main deployment                                                                                       | `{}`                                                         |
 
 See `values.yaml` for configuration notes. Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/coredns/templates/deployment.yaml
+++ b/charts/coredns/templates/deployment.yaml
@@ -95,6 +95,17 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: [ "-conf", "/etc/coredns/Corefile" ]
+        {{- if .Values.deployment.env }}
+        env:
+          {{- range $key, $value := .Values.deployment.env }}
+          - name: {{ $key }}
+            {{- if kindIs "map" $value }}
+{{ toYaml $value | indent 12 }}
+            {{- else }}
+            value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
         volumeMounts:
         - name: config-volume
           mountPath: /etc/coredns

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -335,3 +335,12 @@ deployment:
   name: ""
   ## Annotations for the coredns deployment
   annotations: {}
+  ## Environment variables for the coredns deployment
+  #  env:
+  #    SIMPLE_VAR: value
+  #    COMPLEX_VAR:
+  #      valueFrom:
+  #        secretKeyRef:
+  #          name: my-secret
+  #          key: my-key
+  env: {}


### PR DESCRIPTION
According to the [CoreDNS docs](https://coredns.io/manual/configuration/), environment variables can be used in the `Corefile`. This might make a few things easier to configure, as the server config can be defined in `values.yaml` and small overrides can be done using environment variables in other values files.

This PR adds supports for environment variables to the CoreDNS deployment.