### PR TITLE
Add ability to configure pod level securityContext

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -19,6 +19,8 @@ engine: gotpl
 type: application
 annotations:
   artifacthub.io/changes: |
+    - kind: added
+      description: Added podSecurityContext
     - kind: fixed
       description: Fix assignment of NET_BIND_SERVICE capability
     - kind: fixed

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.22.1
+version: 1.23.0
 appVersion: 1.10.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -21,7 +21,3 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Added podSecurityContext
-    - kind: fixed
-      description: Fix assignment of NET_BIND_SERVICE capability
-    - kind: fixed
-      description: Enable use of pullSecrets with Deployment

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.22.0
+version: 1.22.1
 appVersion: 1.10.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png

--- a/charts/coredns/templates/deployment.yaml
+++ b/charts/coredns/templates/deployment.yaml
@@ -64,6 +64,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -86,6 +86,9 @@ isClusterService: true
 # Optional priority class to be used for the coredns pods. Used for autoscaler if autoscaler.priorityClassName not set.
 priorityClassName: ""
 
+# Configure the pod level securityContext.
+podSecurityContext: {}
+
 # Configure SecurityContext for Pod.
 # Ensure that required linux capability to bind port number below 1024 is assigned (`CAP_NET_BIND_SERVICE`).
 securityContext:


### PR DESCRIPTION
#### Why is this pull request needed and what does it do?
This is needed to allow configuration of the pod level securityContext. The pod level security context can be useful for setting things like seccompProfile at the pod level.

#### Which issues (if any) are related?
N/A

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

