### PR TITLE
Remove deprecated critical-pod annotation

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.23.0
+version: 1.24.0
 appVersion: 1.10.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png

--- a/charts/coredns/templates/deployment-autoscaler.yaml
+++ b/charts/coredns/templates/deployment-autoscaler.yaml
@@ -48,7 +48,6 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap-autoscaler.yaml") . | sha256sum }}
         {{- if .Values.isClusterService }}
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
         {{- end }}
     spec:

--- a/charts/coredns/templates/deployment.yaml
+++ b/charts/coredns/templates/deployment.yaml
@@ -57,7 +57,6 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.isClusterService }}
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
         {{- end }}
 {{- if .Values.podAnnotations }}


### PR DESCRIPTION
spec.template.metadata.annotations[scheduler.alpha.kubernetes.io/critical-pod]: non-functional in v1.16+; use the "priorityClassName" field instead

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?

#### Which issues (if any) are related?


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

