### PR TITLE
fix wrong namespaceSelector in servicemonitor

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.24.3
+version: 1.24.4
 appVersion: 1.10.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -19,5 +19,5 @@ engine: gotpl
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: Added
-      description: Added a job to the github action for repo addition.
+    - kind: fixed
+      description: Fix wrong namespaceSelector in ServiceMonitor when using custom monitoring namespace

--- a/charts/coredns/templates/servicemonitor.yaml
+++ b/charts/coredns/templates/servicemonitor.yaml
@@ -15,6 +15,11 @@ metadata:
 {{- toYaml . | nindent 4 }}
 {{- end }}
 spec:
+  {{- if ne .Values.prometheus.monitor.namespace .Release.Namespace }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name | quote }}


### PR DESCRIPTION

#### Why is this pull request needed and what does it do?
when set prometheus.monitor.namespace to differ namespace, we should use namespaceSelector to specify service namespace

#### Which issues (if any) are related?


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

