### PR TITLE
[Refactor] - Move labels to helpers.tpl

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -19,5 +19,5 @@ engine: gotpl
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: Refacotring
+    - kind: Refactoring
       description: Moved the labels from the the resource to a single helpers.tpl for better readability

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.24.1
+version: 1.24.2
 appVersion: 1.10.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -19,5 +19,5 @@ engine: gotpl
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Added autoscaler podAnnotations
+    - kind: Refacotring
+      description: Moved the labels from the the resource to a single helpers.tpl for better readability

--- a/charts/coredns/templates/_helpers.tpl
+++ b/charts/coredns/templates/_helpers.tpl
@@ -19,6 +19,35 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{/*
+Common labels
+*/}}
+{{- define "coredns.labels" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.isClusterService }}
+k8s-app: {{ template "coredns.k8sapplabel" . }}
+kubernetes.io/cluster-service: "true"
+kubernetes.io/name: "CoreDNS"
+{{- end }}
+app.kubernetes.io/name: {{ template "coredns.name" . }}
+{{- end -}}
+
+{{/*
+Common labels with autoscaler
+*/}}
+{{- define "coredns.labels.autoscaler" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.isClusterService }}
+k8s-app: {{ template "coredns.k8sapplabel" . }}-autoscaler
+kubernetes.io/cluster-service: "true"
+kubernetes.io/name: "CoreDNS"
+{{- end }}
+app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+{{- end -}}
 
 {{/*
 Allow k8s-app label to be overridden

--- a/charts/coredns/templates/clusterrole-autoscaler.yaml
+++ b/charts/coredns/templates/clusterrole-autoscaler.yaml
@@ -4,16 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "coredns.fullname" . }}-autoscaler
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}-autoscaler
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+  labels: {{- include "coredns.labels.autoscaler" . | nindent 4 }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}

--- a/charts/coredns/templates/clusterrole.yaml
+++ b/charts/coredns/templates/clusterrole.yaml
@@ -3,16 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "coredns.fullname" . }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}
+  labels: {{- include "coredns.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/charts/coredns/templates/clusterrolebinding-autoscaler.yaml
+++ b/charts/coredns/templates/clusterrolebinding-autoscaler.yaml
@@ -4,16 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "coredns.fullname" . }}-autoscaler
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}-autoscaler
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+  labels: {{- include "coredns.labels.autoscaler" . | nindent 4 }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}

--- a/charts/coredns/templates/clusterrolebinding.yaml
+++ b/charts/coredns/templates/clusterrolebinding.yaml
@@ -3,16 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "coredns.fullname" . }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}
+  labels: {{- include "coredns.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/coredns/templates/configmap-autoscaler.yaml
+++ b/charts/coredns/templates/configmap-autoscaler.yaml
@@ -5,16 +5,7 @@ apiVersion: v1
 metadata:
   name: {{ template "coredns.fullname" . }}-autoscaler
   namespace:  {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}-autoscaler
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+  labels: {{- include "coredns.labels.autoscaler" . | nindent 4 }}
     {{- if .Values.customLabels }}
     {{- toYaml .Values.customLabels | nindent 4 }}
     {{- end }}

--- a/charts/coredns/templates/configmap.yaml
+++ b/charts/coredns/templates/configmap.yaml
@@ -4,16 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "coredns.fullname" . }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}
+  labels: {{- include "coredns.labels" . | nindent 4 }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}

--- a/charts/coredns/templates/deployment-autoscaler.yaml
+++ b/charts/coredns/templates/deployment-autoscaler.yaml
@@ -5,18 +5,7 @@ kind: Deployment
 metadata:
   name: {{ template "coredns.fullname" . }}-autoscaler
   namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    {{- if not (hasKey .Values.customLabels "k8s-app")}}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}-autoscaler
-    {{- end }}
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+  labels: {{- include "coredns.labels.autoscaler" . | nindent 4 }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}

--- a/charts/coredns/templates/deployment.yaml
+++ b/charts/coredns/templates/deployment.yaml
@@ -4,16 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ default (include "coredns.fullname" .) .Values.deployment.name }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}
+  labels: {{- include "coredns.labels" . | nindent 4 }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}

--- a/charts/coredns/templates/hpa.yaml
+++ b/charts/coredns/templates/hpa.yaml
@@ -8,16 +8,7 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "coredns.fullname" . }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}
+  labels: {{- include "coredns.labels" . | nindent 4 }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}

--- a/charts/coredns/templates/poddisruptionbudget.yaml
+++ b/charts/coredns/templates/poddisruptionbudget.yaml
@@ -3,16 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "coredns.fullname" . }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}
+  labels: {{- include "coredns.labels" . | nindent 4 }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}

--- a/charts/coredns/templates/podsecuritypolicy.yaml
+++ b/charts/coredns/templates/podsecuritypolicy.yaml
@@ -7,17 +7,7 @@ apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "coredns.fullname" . }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- else }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}
-    {{- end }}
+  labels: {{- include "coredns.labels" . | nindent 4 }}
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/charts/coredns/templates/service-metrics.yaml
+++ b/charts/coredns/templates/service-metrics.yaml
@@ -3,16 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "coredns.fullname" . }}-metrics
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}
+  labels: {{- include "coredns.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}

--- a/charts/coredns/templates/service.yaml
+++ b/charts/coredns/templates/service.yaml
@@ -4,16 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ default (include "coredns.fullname" .) .Values.service.name }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}
+  labels: {{- include "coredns.labels" . | nindent 4 }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}

--- a/charts/coredns/templates/serviceaccount-autoscaler.yaml
+++ b/charts/coredns/templates/serviceaccount-autoscaler.yaml
@@ -5,16 +5,7 @@ kind: ServiceAccount
 metadata:
   name: {{ template "coredns.fullname" . }}-autoscaler
   namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}-autoscaler
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+  labels: {{- include "coredns.labels.autoscaler" . | nindent 4 }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}

--- a/charts/coredns/templates/serviceaccount.yaml
+++ b/charts/coredns/templates/serviceaccount.yaml
@@ -3,16 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "coredns.serviceAccountName" . }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}
+  labels: {{- include "coredns.labels" . | nindent 4 }}
   {{- if or .Values.serviceAccount.annotations .Values.customAnnotations }}
   annotations:
     {{- if .Values.customAnnotations }}

--- a/charts/coredns/templates/servicemonitor.yaml
+++ b/charts/coredns/templates/servicemonitor.yaml
@@ -6,16 +6,7 @@ metadata:
   {{- if .Values.prometheus.monitor.namespace }}
   namespace: {{ .Values.prometheus.monitor.namespace }}
   {{- end }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    {{- if .Values.isClusterService }}
-    k8s-app: {{ template "coredns.k8sapplabel" . }}
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-    {{- end }}
-    app.kubernetes.io/name: {{ template "coredns.name" . }}
+  labels: {{- include "coredns.labels" . | nindent 4 }}
     {{- if .Values.prometheus.monitor.additionalLabels }}
 {{ toYaml .Values.prometheus.monitor.additionalLabels | indent 4 }}
     {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?
It would move the labels from the resource manifest to a single helpers.tlp which would make that handling of these labels much more simplified 
#### Which issues (if any) are related?
https://github.com/coredns/helm/issues/104

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

