### PR TITLE
fix indentation for extraContainers

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.27.0
+version: 1.27.1
 appVersion: 1.11.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -20,5 +20,5 @@ engine: gotpl
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Added support for sidecar containers via extraContainers
+    - kind: fixed
+      description: Fixed indentation for sidecar containers

--- a/charts/coredns/templates/deployment-autoscaler.yaml
+++ b/charts/coredns/templates/deployment-autoscaler.yaml
@@ -92,7 +92,7 @@ spec:
         {{- if .Values.autoscaler.customFlags }}
 {{ toYaml .Values.autoscaler.customFlags | indent 10 }}
         {{- end }}
-{{- end }}
 {{- if .Values.autoscaler.extraContainers }}
-{{ toYaml .Values.autoscaler.extraContainers | indent 8 }}
+{{ toYaml .Values.autoscaler.extraContainers | indent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/coredns/templates/deployment.yaml
+++ b/charts/coredns/templates/deployment.yaml
@@ -136,7 +136,7 @@ spec:
 {{- toYaml .Values.securityContext | nindent 10 }}
 {{- end }}
 {{- if .Values.extraContainers }}
-{{ toYaml .Values.extraContainers | indent 8 }}
+{{ toYaml .Values.extraContainers | indent 6 }}
 {{- end }}
       volumes:
         - name: config-volume


### PR DESCRIPTION
#### Why is this pull request needed and what does it do?

#141 added support for sidecar containers, but the indentation is wrong. This fixes it so the template can render correctly.

#### Which issues (if any) are related?

Issue caused from #141 if using the `extraContainers` field.

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

