### PR TITLE
Ability to override defaultMode for extraSecrets

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.28.0
+version: 1.28.1
 appVersion: 1.11.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -21,4 +21,4 @@ type: application
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: topologySpreadConstraints can be templated values
+      description: Added option to override defaultMode for extraSecrets

--- a/charts/coredns/templates/deployment.yaml
+++ b/charts/coredns/templates/deployment.yaml
@@ -153,7 +153,7 @@ spec:
         - name: {{ .name }}
           secret:
             secretName: {{ .name }}
-            defaultMode: 400
+            defaultMode: {{ default 400 .defaultMode }}
 {{- end }}
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8 }}

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -246,8 +246,10 @@ extraVolumeMounts: []
 extraSecrets: []
 # - name: etcd-client-certs
 #   mountPath: /etc/coredns/tls/etcd
+#   defaultMode: 420
 # - name: some-fancy-secret
 #   mountPath: /etc/wherever
+#   defaultMode: 440
 
 # To support legacy deployments using CoreDNS with the "k8s-app: kube-dns" label selectors.
 # See https://github.com/coredns/helm/blob/master/charts/coredns/README.md#adopting-existing-coredns-resources


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?
This request is needed because the `defaultMode` value of `400` is hardcoded into the [deployment.yaml file](https://github.com/coredns/helm/blob/master/charts/coredns/templates/deployment.yaml#L156) for any secrets defined in  `.Values.extraSecrets` which causes the CoreDNS pod to crash loop when using etcd as a back end with a "permission denied" error for the file mounted.  Changing this to `420` resolves the issue, but the user should be able to set the `defaultMode` using the values file.  This exposes the setting but uses a default of `400`.

#### Which issues (if any) are related?
https://github.com/coredns/helm/issues/144

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
