### PR TITLE
fix: add .Release.Namespace in metadata

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.28.1
+version: 1.28.2
 appVersion: 1.11.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -20,5 +20,5 @@ engine: gotpl
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Added option to override defaultMode for extraSecrets
+    - kind: fixed
+      description: add .Release.Namespace in metadata

--- a/charts/coredns/templates/configmap.yaml
+++ b/charts/coredns/templates/configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "coredns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "coredns.labels" . | nindent 4 }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}

--- a/charts/coredns/templates/deployment.yaml
+++ b/charts/coredns/templates/deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ default (include "coredns.fullname" .) .Values.deployment.name }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "coredns.labels" . | nindent 4 }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- if .Values.customLabels }}

--- a/charts/coredns/templates/hpa.yaml
+++ b/charts/coredns/templates/hpa.yaml
@@ -8,6 +8,7 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "coredns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "coredns.labels" . | nindent 4 }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}

--- a/charts/coredns/templates/poddisruptionbudget.yaml
+++ b/charts/coredns/templates/poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "coredns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "coredns.labels" . | nindent 4 }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}

--- a/charts/coredns/templates/service-metrics.yaml
+++ b/charts/coredns/templates/service-metrics.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "coredns.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "coredns.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
 {{- if .Values.customLabels }}

--- a/charts/coredns/templates/service.yaml
+++ b/charts/coredns/templates/service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ default (include "coredns.fullname" .) .Values.service.name }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "coredns.labels" . | nindent 4 }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}

--- a/charts/coredns/templates/serviceaccount.yaml
+++ b/charts/coredns/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "coredns.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "coredns.labels" . | nindent 4 }}
   {{- if or .Values.serviceAccount.annotations .Values.customAnnotations }}
   annotations:


### PR DESCRIPTION
Adding .Release.Namespace in metadata fixes issues when rendering template with 'helm template --namespace'. Without it, the rendered templates do not have the namespace defined which is problematic when using a gitops approach.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).
