### PR TITLE
Ignore duplicate strings in the fullname helper template

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -19,5 +19,7 @@ maintainers:
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: add .Release.Namespace in metadata
+    - kind: changed
+      description: Ignore duplicate strings in the fullname helper template
+    - kind: removed
+      description: Removed deprecated "engine: gotpl" from the Chart.yaml

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 2.0.0
+version: 1.29.0
 appVersion: 1.11.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.28.2
+version: 2.0.0
 appVersion: 1.11.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -16,7 +16,6 @@ maintainers:
   - name: haad
   - name: hagaibarel
   - name: shubham-cmyk
-engine: gotpl
 type: application
 annotations:
   artifacthub.io/changes: |

--- a/charts/coredns/templates/_helpers.tpl
+++ b/charts/coredns/templates/_helpers.tpl
@@ -15,7 +15,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?
Current chart was setting not smart names for all object it was creating.
Specifically if release name equals chart name - in this case `coredns` - release name should be ignored, to avoid duplicates in the name.

- Before the fix: names with `coredns-coredns` string in them.
```txt
kubectl -n kube-system get all,sa,clusterrole,clusterrolebinding,smon -l app.kubernetes.io/instance=coredns
NAME                                   READY   STATUS    RESTARTS      AGE
pod/coredns-coredns-6db9976d78-drpdc   1/1     Running   1 (11h ago)   15h

NAME                              TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)         AGE
service/coredns-coredns-metrics   ClusterIP   10.30.232.118   <none>        9153/TCP        15h
service/kube-dns                  ClusterIP   10.30.0.10      <none>        53/UDP,53/TCP   15h

NAME                              READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/coredns-coredns   1/1     1            1           15h

NAME                                         DESIRED   CURRENT   READY   AGE
replicaset.apps/coredns-coredns-6db9976d78   1         1         1       15h

NAME                             SECRETS   AGE
serviceaccount/coredns-coredns   0         15h

NAME                                                    CREATED AT
clusterrole.rbac.authorization.k8s.io/coredns-coredns   2023-12-27T13:55:55Z

NAME                                                           ROLE                          AGE
clusterrolebinding.rbac.authorization.k8s.io/coredns-coredns   ClusterRole/coredns-coredns   15h

NAME                                                   AGE
servicemonitor.monitoring.coreos.com/coredns-coredns   15h
```

- After the fix: clean names when helm release is named `coredns`
```txt
kubectl -n kube-system get all,sa,clusterrole,clusterrolebinding,smon -l app.kubernetes.io/instance=coredns
NAME                           READY   STATUS    RESTARTS   AGE
pod/coredns-7545f4d965-sm4wt   1/1     Running   0          55s

NAME                      TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)         AGE
service/coredns           ClusterIP   10.30.0.10     <none>        53/UDP,53/TCP   56s
service/coredns-metrics   ClusterIP   10.30.10.176   <none>        9153/TCP        56s

NAME                      READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/coredns   1/1     1            1           56s

NAME                                 DESIRED   CURRENT   READY   AGE
replicaset.apps/coredns-7545f4d965   1         1         1       56s

NAME                     SECRETS   AGE
serviceaccount/coredns   0         56s

NAME                                            CREATED AT
clusterrole.rbac.authorization.k8s.io/coredns   2023-12-28T05:58:55Z

NAME                                                   ROLE                  AGE
clusterrolebinding.rbac.authorization.k8s.io/coredns   ClusterRole/coredns   56s

NAME                                           AGE
servicemonitor.monitoring.coreos.com/coredns   56s
```

**Extra additional change:**
Removed deprecated "engine: gotpl" from the Chart.yaml, that was caught by my linter.
<img width="627" alt="Screen Shot 2023-12-28 at 10 33 57" src="https://github.com/coredns/helm/assets/5287237/c1eaa85e-ac8c-46b3-a123-a8da4357bfae">


#### Which issues (if any) are related?
Fixes https://github.com/coredns/helm/issues/155

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

