### PR TITLE
Remove biased annotations from prometheus.service.annotations

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.29.0
+version: 1.29.1
 appVersion: 1.11.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -20,6 +20,4 @@ type: application
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Ignore duplicate strings in the fullname helper template
-    - kind: removed
-      description: Removed deprecated "engine: gotpl" from the Chart.yaml
+      description: prometheus.service.annotations map in the default values.yaml should be blank {}

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -39,9 +39,10 @@ serviceType: "ClusterIP"
 prometheus:
   service:
     enabled: false
-    annotations:
-      prometheus.io/scrape: "true"
-      prometheus.io/port: "9153"
+    annotations: {}
+    # annotations:
+    #   prometheus.io/scrape: "true"
+    #   prometheus.io/port: "9153"
   monitor:
     enabled: false
     additionalLabels: {}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?
Makes the default prometheus.service.annotations blank `{}` map. Removing any bias.
#### Which issues (if any) are related?
Fixes https://github.com/coredns/helm/issues/157

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

