### PR TITLE
Introduced ability to use KEDA triggers for autoscaling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,6 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.29.0
+version: 1.29.1
 appVersion: 1.11.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -19,7 +19,5 @@ maintainers:
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Ignore duplicate strings in the fullname helper template
-    - kind: removed
-      description: Removed deprecated "engine: gotpl" from the Chart.yaml
+    - kind: added
+      description: Ability to use KEDA triggers for autoscaling

--- a/charts/coredns/README.md
+++ b/charts/coredns/README.md
@@ -14,7 +14,7 @@ $ helm --namespace=kube-system install coredns coredns/coredns
 This chart bootstraps a [CoreDNS](https://github.com/coredns/coredns) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. This chart will provide DNS Services and can be deployed in multiple configuration to support various scenarios listed below:
 
 - CoreDNS as a cluster dns service and a drop-in replacement for Kube/SkyDNS. This is the default mode and CoreDNS is deployed as cluster-service in kube-system namespace. This mode is chosen by setting `isClusterService` to true.
-- CoreDNS as an external dns service. In this mode CoreDNS is deployed as any kubernetes app in user specified namespace. The CoreDNS service can be exposed outside the cluster by using using either the NodePort or LoadBalancer type of service. This mode is chosen by setting `isClusterService` to false.
+- CoreDNS as an external dns service. In this mode CoreDNS is deployed as any kubernetes app in user specified namespace. The CoreDNS service can be exposed outside the cluster by using either the NodePort or LoadBalancer type of service. This mode is chosen by setting `isClusterService` to false.
 - CoreDNS as an external dns provider for kubernetes federation. This is a sub case of 'external dns service' which uses etcd plugin for CoreDNS backend. This deployment mode as a dependency on `etcd-operator` chart, which needs to be pre-installed.
 
 ## Prerequisites
@@ -47,9 +47,9 @@ The command removes all the Kubernetes components associated with the chart and 
 ## Configuration
 
 | Parameter                                      | Description                                                                                                                               | Default                                                      |
-| :--------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------- |
+|:-----------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------|
 | `image.repository`                             | The image repository to pull from                                                                                                         | coredns/coredns                                              |
-| `image.tag`                                    | The image tag to pull from (derived from Chart.yaml)                                                                                      | ``                                                      |
+| `image.tag`                                    | The image tag to pull from (derived from Chart.yaml)                                                                                      | ``                                                           |
 | `image.pullPolicy`                             | Image pull policy                                                                                                                         | IfNotPresent                                                 |
 | `image.pullSecrets`                            | Specify container image pull secrets                                                                                                      | `[]`                                                         |
 | `replicaCount`                                 | Number of replicas                                                                                                                        | 1                                                            |
@@ -110,6 +110,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `hpa.minReplicas`                              | Hpa minimum number of CoreDNS replicas                                                                                                    | `1`                                                          |
 | `hpa.maxReplicas`                              | Hpa maximum number of CoreDNS replicas                                                                                                    | `2`                                                          |
 | `hpa.metrics`                                  | Metrics definitions used by Hpa to scale up and down                                                                                      | {}                                                           |
+| `keda.enabled`                                 | Optionally enable KEDA for CoreDNS                                                                                                        | `false`                                                      |
+| `keda.fallback`                                | Optional. Section to specify fallback options                                                                                             | {}                                                           |
+| `keda.advanced`                                | Optional. Section to specify advanced options                                                                                             | {}                                                           |
+| `keda.triggers`                                | List of triggers to activate scaling of the target resource                                                                               | []                                                           |
 | `autoscaler.enabled`                           | Optionally enabled a cluster-proportional-autoscaler for CoreDNS                                                                          | `false`                                                      |
 | `autoscaler.coresPerReplica`                   | Number of cores in the cluster per CoreDNS replica                                                                                        | `256`                                                        |
 | `autoscaler.nodesPerReplica`                   | Number of nodes in the cluster per CoreDNS replica                                                                                        | `16`                                                         |
@@ -187,7 +191,7 @@ the autoscaler deployment.
 `replicaCount` is ignored if this is enabled.
 
 By setting `hpa.enabled = true` a [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
-is enabled for Coredns deployment. This can scale number of replicas based on meitrics
+is enabled for Coredns deployment. This can scale number of replicas based on metrics
 like CpuUtilization, MemoryUtilization or Custom ones.
 
 ## Adopting existing CoreDNS resources

--- a/charts/coredns/templates/deployment-autoscaler.yaml
+++ b/charts/coredns/templates/deployment-autoscaler.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.autoscaler.enabled) (not .Values.hpa.enabled) }}
+{{- if and (.Values.autoscaler.enabled) (not .Values.hpa.enabled) (not .Values.keda.enabled) }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/coredns/templates/deployment.yaml
+++ b/charts/coredns/templates/deployment.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if and (not .Values.autoscaler.enabled) (not .Values.hpa.enabled) }}
+  {{- if and (not .Values.autoscaler.enabled) (not .Values.hpa.enabled) (not .Values.keda.enabled) }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   strategy:

--- a/charts/coredns/templates/scaledobject.yaml
+++ b/charts/coredns/templates/scaledobject.yaml
@@ -1,0 +1,32 @@
+{{- if and (.Values.keda.enabled) (not .Values.hpa.enabled) (not .Values.autoscaler.enabled) }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "coredns.labels" . | nindent 4 }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+{{- with .Values.customAnnotations }}
+  annotations:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ default (include "coredns.fullname" .) .Values.deployment.name }}
+  pollingInterval: {{ .Values.keda.pollingInterval | default 30 }}
+  cooldownPeriod:  {{ .Values.keda.cooldownPeriod | default 300 }}
+  idleReplicaCount: {{ .Values.keda.idleReplicaCount | default 0 }}
+  minReplicaCount: {{ .Values.keda.minReplicaCount | default 1 }}
+  maxReplicaCount: {{ .Values.keda.maxReplicaCount | default 100 }}
+  fallback:
+    {{- toYaml .Values.keda.fallback | nindent 4 }}
+  advanced:
+    {{- toYaml .Values.keda.advanced | nindent 4 }}
+  triggers:
+    {{- toYaml .Values.keda.triggers | nindent 4 }}
+{{- end }}

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -289,6 +289,24 @@ hpa:
   maxReplicas: 2
   metrics: []
 
+## Configue KEDA (Kubernetes Event-driven Autoscaling) for coredns
+# See https://keda.sh/docs/2.14/concepts/scaling-deployments/#scaledobject-spec
+keda:
+  # Enabled the KEDA
+  enabled: false
+
+  # pollingInterval: 30
+  # cooldownPeriod: 300
+  # minReplicaCount: 1
+  # maxReplicaCount: 100
+
+  # Optional. Section to specify fallback options
+  fallback: {}
+  # Optional. Section to specify advanced options
+  advanced: {}
+  # List of triggers to activate scaling of the target resource
+  triggers: []
+
 ## Configue a cluster-proportional-autoscaler for coredns
 # See https://github.com/kubernetes-incubator/cluster-proportional-autoscaler
 autoscaler:


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?

Introduced ability to use KEDA triggers for autoscaling

#### Which issues (if any) are related?

N/A

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

