### PR TITLE
add sysctl net.ipv4.ip_unprivileged_port_start 53

### DIFF
--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -87,8 +87,10 @@ isClusterService: true
 priorityClassName: ""
 
 # Configure the pod level securityContext.
-podSecurityContext: {}
-
+podSecurityContext:
+  sysctls:
+  - name: net.ipv4.ip_unprivileged_port_start
+    value: "53"
 # Configure SecurityContext for Pod.
 # Ensure that required linux capability to bind port number below 1024 is assigned (`CAP_NET_BIND_SERVICE`).
 securityContext:


### PR DESCRIPTION
ref https://github.com/coredns/deployment/pull/298

https://github.com/kubernetes/kubernetes/pull/103326 marked it as safe sysctl since Kubernetes v1.22.

Kernel 4.11 add this: https://github.com/torvalds/linux/commit/4548b683b78137f8eadeb312b94e20bb0d4a7141 which is per namespaced.

xref https://github.com/coredns/coredns/issues/6716 and https://github.com/kubernetes/kubernetes/issues/125226.