### PR TITLE
added: support service loadBalancerClass

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.32.0
+version: 1.33.0
 appVersion: 1.11.3
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -21,3 +21,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Upgrade CoreDNS to 1.11.3
+    - kind: added
+      description: Add support for specifying the service loadBalancerClass.

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -19,7 +19,5 @@ maintainers:
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade CoreDNS to 1.11.3
     - kind: added
       description: Add support for specifying the service loadBalancerClass.

--- a/charts/coredns/templates/service.yaml
+++ b/charts/coredns/templates/service.yaml
@@ -46,6 +46,9 @@ spec:
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
   ports:
 {{ include "coredns.servicePorts" . | indent 2 -}}
   type: {{ default "ClusterIP" .Values.serviceType }}

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -54,6 +54,7 @@ service:
 # clusterIP: ""
 # clusterIPs: []
 # loadBalancerIP: ""
+# loadBalancerClass: ""
 # externalIPs: []
 # externalTrafficPolicy: ""
 # ipFamilyPolicy: ""


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?

This pull request adds a value for configuring the service's `loadBalancerClass` field. This allows the chart to easily be deployed in environments that have multiple load balancers that could potentially satisfy Kubernetes LoadBalancer services. 

#### Which issues (if any) are related?


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

