### PR TITLE
Support different service and container ports

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.33.0
+version: 1.34.0
 appVersion: 1.11.3
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -20,4 +20,4 @@ type: application
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Add support for specifying the service loadBalancerClass.
+      description: Support different service and container ports

--- a/charts/coredns/templates/_helpers.tpl
+++ b/charts/coredns/templates/_helpers.tpl
@@ -70,10 +70,11 @@ Generate the list of ports automatically from the server definitions
     {{- range .Values.servers -}}
         {{/* Capture port to avoid scoping awkwardness */}}
         {{- $port := toString .port -}}
+        {{- $serviceport := default .port .servicePort -}}
 
         {{/* If none of the server blocks has mentioned this port yet take note of it */}}
         {{- if not (hasKey $ports $port) -}}
-            {{- $ports := set $ports $port (dict "istcp" false "isudp" false) -}}
+            {{- $ports := set $ports $port (dict "istcp" false "isudp" false "serviceport" $serviceport) -}}
         {{- end -}}
         {{/* Retrieve the inner dict that holds the protocols for a given port */}}
         {{- $innerdict := index $ports $port -}}
@@ -116,10 +117,10 @@ Generate the list of ports automatically from the server definitions
     {{- range $port, $innerdict := $ports -}}
         {{- $portList := list -}}
         {{- if index $innerdict "isudp" -}}
-            {{- $portList = append $portList (dict "port" ($port | int) "protocol" "UDP" "name" (printf "udp-%s" $port)) -}}
+            {{- $portList = append $portList (dict "port" (get $innerdict "serviceport") "protocol" "UDP" "name" (printf "udp-%s" $port) "targetPort" ($port | int)) -}}
         {{- end -}}
         {{- if index $innerdict "istcp" -}}
-            {{- $portList = append $portList (dict "port" ($port | int) "protocol" "TCP" "name" (printf "tcp-%s" $port)) -}}
+            {{- $portList = append $portList (dict "port" (get $innerdict "serviceport") "protocol" "TCP" "name" (printf "tcp-%s" $port) "targetPort" ($port | int)) -}}
         {{- end -}}
 
         {{- range $portDict := $portList -}}

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -103,6 +103,8 @@ servers:
 - zones:
   - zone: .
   port: 53
+  # -- expose the service on a different port
+  # servicePort: 5353
   # If serviceType is nodePort you can specify nodePort here
   # nodePort: 30053
   # hostPort: 53


### PR DESCRIPTION
#### Why is this pull request needed and what does it do?

This PR allows exposing coreDNS on a service port different from the ports exposed by the container.
We want to expose coreDNS publicly. To increase security we would like to open a container port above 1024 to not add the `NET_BIND_SERVICE` capability, while still exposing the service on port 53.

The change adds an optional `servers.servicePort` key that can be used to set a service port. If this value is not set, the value of the `servers.port` is used both as service and container port (old behavior). Thus, the change is fully backwards compatible.
```
helm package . && helm template coredns coredns-1.33.0.tgz -f values.yaml > manifests2.yaml
...
diff manifests.yaml manifests2.yaml                                                        
111,112c111,112
<   - {"name":"udp-53","port":53,"protocol":"UDP"}
<   - {"name":"tcp-53","port":53,"protocol":"TCP"}
---
>   - {"name":"udp-53","port":53,"protocol":"UDP","targetPort":53}
>   - {"name":"tcp-53","port":53,"protocol":"TCP","targetPort":53}
```

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

