### PR TITLE
Fix `trafficDistribution` documentation issue

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.35.0
+version: 1.35.1
 appVersion: 1.11.3
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -19,5 +19,5 @@ maintainers:
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Support `trafficDistribution` property for service
+    - kind: changed
+      description: Move `trafficDistribution` key to correct path

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -43,7 +43,6 @@ prometheus:
       prometheus.io/scrape: "true"
       prometheus.io/port: "9153"
     selector: {}
-    # trafficDistribution: PreferClose
   monitor:
     enabled: false
     additionalLabels: {}
@@ -59,6 +58,7 @@ service:
 # externalIPs: []
 # externalTrafficPolicy: ""
 # ipFamilyPolicy: ""
+# trafficDistribution: PreferClose
   # The name of the Service
   # If not set, a name is generated using the fullname template
   name: ""


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?

Fix a minor documentation oops on my last PR #176, in `values.yaml` the new `trafficDistribution` key was at `prometheus.service` instead of `service`, apologies for the noise.

#### Which issues (if any) are related?

None

Checklist:

* [X] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [X] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [X] Any new values are backwards compatible and/or have sensible default.
* [X] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

