### PR TITLE
fix: add default value for clusterRole name override

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.36.0
+version: 1.36.1
 appVersion: 1.11.3
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -19,5 +19,5 @@ maintainers:
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Add environment variables on container specs
+    - kind: fix
+      description: Add default values to chart to fix cluster role name templating issue

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -82,6 +82,11 @@ rbac:
   # If not set and create is true, a name is generated using the fullname template
   # name:
 
+clusterRole:
+  # By default a name is generated using the fullname template.
+  # Override here if desired:
+  nameOverride: ""
+
 # isClusterService specifies whether chart should be deployed as cluster-service or normal k8s app.
 isClusterService: true
 


### PR DESCRIPTION
#### Why is this pull request needed and what does it do?

This addresses a templating error by adding a default value to the chart.

A thing the maintainers of this repo likely already know but that I felt the need to check while making this PR: setting a Helm value to an empty string results in it being treated as false in if/else statements (https://helm.sh/docs/chart_template_guide/control_structures/#ifelse). So this should be a safe default.

#### Which issues (if any) are related?

https://github.com/coredns/helm/issues/180

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

