### PR TITLE
feat(oci): add publishing of helm chart to oci repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,20 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed to pull git repo and create "chart-release"
+      id-token: write # needed for signing the images with GitHub OIDC Token
     steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.7.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -19,13 +32,20 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.13.1
-
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Publish chart to ghcr.io
+        run: |
+          helm package charts/coredns
+          helm push coredns-*.tgz oci://ghcr.io/coredns/charts
+          rm -rf coredns-*.tgz
+
+      - name: Sign artifacts with Cosign
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        working-directory: charts/coredns
+        run: |-
+          cosign sign ghcr.io/coredns/charts/coredns:$(yq .version Chart.yaml) --yes

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.37.3
+version: 1.38.0
 appVersion: 1.11.4
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -19,5 +19,7 @@ maintainers:
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fix helm install when using docker inmutable tags
+    - kind: added
+      description: Adds publishing to github registry
+    - kind: added
+      description: Adds signing of helm chart

--- a/charts/coredns/README.md
+++ b/charts/coredns/README.md
@@ -34,6 +34,16 @@ The command deploys CoreDNS on the Kubernetes cluster in the default configurati
 
 > **Tip**: List all releases using `helm list --all-namespaces`
 
+## OCI installing
+
+The chart can also be installed using the following:
+
+```console
+$ helm --namespace=kube-system install coredns oci://ghcr.io/coredns/charts/coredns --version 1.38.0
+```
+
+The command deploys the `1.38.0` version of CoreDNS on the Kubernetes cluster in the default configuration.
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `coredns` deployment:


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?

- Adds publishing of coredns chart to ghcr.io registry
- Adds cosign keyless signing to actions

#### Which issues (if any) are related?
- fixes #182

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

