### PR TITLE
Use image.tag for app.kubernetes.io/version label if defined

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.37.1
+version: 1.37.2
 appVersion: 1.11.4
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -19,5 +19,5 @@ maintainers:
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Fixed typo in readme
+    - kind: fixed
+      description: Use image.tag for app.kubernetes.io/version label if defined

--- a/charts/coredns/templates/deployment.yaml
+++ b/charts/coredns/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ default (include "coredns.fullname" .) .Values.deployment.name }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "coredns.labels" . | nindent 4 }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}


### PR DESCRIPTION
#### Why is this pull request needed and what does it do?

The `Deployment` object has a label named `app.kubernetes.io/version` which value is `Chart.AppVersion`. But this is not always true because the chart allows to specify the image tag with the `image.tag`.

I think it makes more sense to use the same mechanism as with the image tag. Use `Chart.AppVersion` by default but use `image.tag` if present.

#### Which issues (if any) are related?
 n/a

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

