### PR TITLE
Fix helm install when using docker inmutable tags

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.37.2
+version: 1.37.3
 appVersion: 1.11.4
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -20,4 +20,4 @@ type: application
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Use image.tag for app.kubernetes.io/version label if defined
+      description: Fix helm install when using docker inmutable tags

--- a/charts/coredns/templates/deployment.yaml
+++ b/charts/coredns/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ default (include "coredns.fullname" .) .Values.deployment.name }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "coredns.labels" . | nindent 4 }}
-    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | replace ":" "-" | replace "@" "_" | trunc 63 | trimSuffix "-" | quote }}
 {{- if .Values.customLabels }}
 {{ toYaml .Values.customLabels | indent 4 }}
 {{- end }}


### PR DESCRIPTION
#### Why is this pull request needed and what does it do?

A bug was introduced in release `v1.37.2` that made helm fail when using a docker inmutable tag as `v1.12.0@sha256:40384aa1f5ea6bfdc77997d243aec73da05f27aed0c5e9d65bfa98933c519d97`. This happened because there are some restrictions documented in kubernetes labels ([documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)), e.g. a length of 63 characters, only alphanumeric and `_`, `-` and `.` characters.

This PR attempts to fix the problem described above. Some filters were added to filter out the invalid characters present in a docker inmutable label (`@` and `:`), and the length truncated to 63 characters.

#### Which issues (if any) are related?

- https://github.com/coredns/helm/issues/191

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

