### PR TITLE
fix: align imagePullSecrets in Deployment and ServiceAccount

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.39.0
+version: 1.39.1
 appVersion: 1.12.0
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -19,5 +19,5 @@ maintainers:
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade to CoreDNS 1.12.0
+    - kind: fixed
+      description: align imagePullSecrets in Deployment and ServiceAccount

--- a/charts/coredns/templates/deployment-autoscaler.yaml
+++ b/charts/coredns/templates/deployment-autoscaler.yaml
@@ -60,7 +60,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.autoscaler.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if not (empty .Values.autoscaler.image.pullSecrets) }}
+      {{- if .Values.autoscaler.image.pullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.autoscaler.image.pullSecrets | indent 8 }}
       {{- end }}

--- a/charts/coredns/templates/deployment.yaml
+++ b/charts/coredns/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if not (empty .Values.image.pullSecrets) }}
+      {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
       {{- end }}

--- a/charts/coredns/templates/serviceaccount-autoscaler.yaml
+++ b/charts/coredns/templates/serviceaccount-autoscaler.yaml
@@ -15,8 +15,6 @@ metadata:
 {{- end }}
 {{- if .Values.autoscaler.image.pullSecrets }}
 imagePullSecrets:
-{{- range .Values.autoscaler.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
+{{ toYaml .Values.autoscaler.image.pullSecrets | indent 2 }}
 {{- end }}
 {{- end }}

--- a/charts/coredns/templates/serviceaccount.yaml
+++ b/charts/coredns/templates/serviceaccount.yaml
@@ -16,8 +16,6 @@ metadata:
   {{- end }}
 {{- if .Values.image.pullSecrets }}
 imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
+{{ toYaml .Values.image.pullSecrets | indent 2 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?

Fixes the misalignment between the structure expected for `image.pullSecrets` in `deployment.yaml`/`deployment-autoscaler.yaml` and `serviceaccount.yaml`/`serviceaccount-autoscaler.yaml` which made it impossible to use  imagePullSecrets because they produced invalid manifests.

I also took the opportunity to align the `if` statements in the `Deployment` templates to what is used in the `ServiceAccount` templates for consistency.

#### Which issues (if any) are related?

Fixes https://github.com/coredns/helm/issues/154

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

