### PR TITLE
fix: improve default readiness probe config for shutdown

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.39.1
+version: 1.39.2
 appVersion: 1.12.0
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -20,4 +20,4 @@ type: application
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: align imagePullSecrets in Deployment and ServiceAccount
+      description: improve default readiness probe config for shutdown

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -118,7 +118,7 @@ servers:
   # Serves a /health endpoint on :8080, required for livenessProbe
   - name: health
     configBlock: |-
-      lameduck 5s
+      lameduck 10s
   # Serves a /ready endpoint on :8181, required for readinessProbe
   - name: ready
   # Required to query kubernetes API for data
@@ -174,9 +174,9 @@ livenessProbe:
 readinessProbe:
   enabled: true
   initialDelaySeconds: 30
-  periodSeconds: 10
+  periodSeconds: 5
   timeoutSeconds: 5
-  failureThreshold: 5
+  failureThreshold: 1
   successThreshold: 1
 
 # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core


### PR DESCRIPTION
On shutdown coredns will wait what is configured for lameduck and continue handling connections. At the same time it will fail readiness probes.

In order to give readiness checks a chance to remove the instance from the service we need to lower the failure threshold and the interval.

This is to avoid failing DNS requests in a busy cluster when coredns is being scaled down.

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?

We used a [dns-test-container](https://github.com/sturrent/dns-test-container) and did the following procedure to get this result:

We configured coredns as it is default by EKS `lameduck 5s` and `readinessProbe: periodSeconds=10s failureThreshold=3`

1. Before the test we scaled coredns to 20 instances manually
2. We started the tests and waited roughly 10 seconds
3. We scaled coredns to 1 instance manually
4. Waited for the test to finish

![DNS losses with current configuration](https://github.com/user-attachments/assets/a928b323-2eff-4bbc-acfb-366e7b945128)

This test was executed in a cluster running ~1000 pods.

With this change in place we get no losses in DNS resolution when repeating this test

![DNS no losses](https://github.com/user-attachments/assets/c7c59af8-d490-4a9d-8a7f-fc0b47ad35f6)


#### Which issues (if any) are related?

The issue is described above.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.


