### PR TITLE
fix supported schemes: add https:// to tcp-only scheme list

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.39.2
+version: 1.39.3
 appVersion: 1.12.0
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -20,4 +20,4 @@ type: application
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: improve default readiness probe config for shutdown
+      description: add https:// to tcp-only scheme list

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -19,5 +19,5 @@ maintainers:
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
+    - kind: added
       description: add https:// to tcp-only scheme list

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.39.3
+version: 1.40.0
 appVersion: 1.12.0
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png

--- a/charts/coredns/templates/_helpers.tpl
+++ b/charts/coredns/templates/_helpers.tpl
@@ -83,7 +83,7 @@ Generate the list of ports automatically from the server definitions
         Look at each of the zones and check which protocol they serve
         At the moment the following are supported by CoreDNS:
         UDP: dns://
-        TCP: tls://, grpc://
+        TCP: tls://, grpc://, https://
         */}}
         {{- range .zones -}}
             {{- if has (default "" .scheme) (list "dns://") -}}
@@ -94,7 +94,7 @@ Generate the list of ports automatically from the server definitions
                 {{- $innerdict := set $innerdict "isudp" true -}}
             {{- end -}}
 
-            {{- if has (default "" .scheme) (list "tls://" "grpc://") -}}
+            {{- if has (default "" .scheme) (list "tls://" "grpc://" "https://") -}}
                 {{- $innerdict := set $innerdict "istcp" true -}}
             {{- end -}}
         {{- end -}}
@@ -155,7 +155,7 @@ Generate the list of ports automatically from the server definitions
         Look at each of the zones and check which protocol they serve
         At the moment the following are supported by CoreDNS:
         UDP: dns://
-        TCP: tls://, grpc://
+        TCP: tls://, grpc://, https://
         */}}
         {{- range .zones -}}
             {{- if has (default "" .scheme) (list "dns://") -}}
@@ -166,7 +166,7 @@ Generate the list of ports automatically from the server definitions
                 {{- $innerdict := set $innerdict "isudp" true -}}
             {{- end -}}
 
-            {{- if has (default "" .scheme) (list "tls://" "grpc://") -}}
+            {{- if has (default "" .scheme) (list "tls://" "grpc://" "https://") -}}
                 {{- $innerdict := set $innerdict "istcp" true -}}
             {{- end -}}
         {{- end -}}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?
Creating DoH listener via chart tries to use both TCP and UDP for the service, while only TCP is appropriate. Trying to expose such service via load balancer in some cloud providers leads to issues with no ability to create TCP and UDP listeners on the same port.

This PR adds `https://` to TCP-only scheme list.

#### Which issues (if any) are related?


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

