### PR TITLE
Added Helm unit tests for CoreDNS chart components

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -16,6 +16,9 @@ jobs:
         with:
           version: v3.13.1
 
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+
       - name: Add Helm repo
         run: |
           helm repo add cpa https://kubernetes-sigs.github.io/cluster-proportional-autoscaler
@@ -35,6 +38,42 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
+
+      - name: Run Helm unit tests
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          for chart in $(ct list-changed --target-branch ${{ github.event.repository.default_branch }}); do
+            echo "Running unit tests for $chart"
+            helm unittest --strict $chart
+          done
+      - name: Run Helm unit tests
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          mkdir -p test-results
+          for chart in $(ct list-changed --target-branch ${{ github.event.repository.default_branch }}); do
+            echo "Running unit tests for $chart"
+            helm unittest --strict --output-type JUnit \
+              --output-file test-results/$(basename $chart)-helm-unittest.xml $chart
+          done
+      - name: Upload Helm unittest report
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: helm-unittest-reports
+          path: test-results/
+
+      - name: Publish JUnit test results
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: mikepenz/action-junit-report@v5
+        with:
+          report_paths: test-results/*.xml
+          check_name: Helm Unittest Report
+          fail_on_failure: true
+          require_tests: true
+          require_passed_tests: true
+          include_passed: true
+          detailed_summary: true
+          job_summary: true
 
       - name: Run chart-testing (lint)
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -38,14 +38,6 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
-
-      - name: Run Helm unit tests
-        if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          for chart in $(ct list-changed --target-branch ${{ github.event.repository.default_branch }}); do
-            echo "Running unit tests for $chart"
-            helm unittest --strict $chart
-          done
       - name: Run Helm unit tests
         if: steps.list-changed.outputs.changed == 'true'
         run: |

--- a/charts/coredns/.helmignore
+++ b/charts/coredns/.helmignore
@@ -20,3 +20,4 @@
 .idea/
 *.tmproj
 OWNERS
+*.tests

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.41.0
+version: 1.42.0
 appVersion: 1.12.0
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -20,4 +20,4 @@ type: application
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: bump cluster-proportional-autoscaler to v1.9.0
+      description: Added Helm unit tests for CoreDNS chart components

--- a/charts/coredns/README.md
+++ b/charts/coredns/README.md
@@ -44,6 +44,57 @@ $ helm --namespace=kube-system install coredns oci://ghcr.io/coredns/charts/core
 
 The command deploys the `1.38.0` version of CoreDNS on the Kubernetes cluster in the default configuration.
 
+## Helm Unit Testing & Debugging Guide
+
+This document explains how to write, run, and debug Helm unit tests for this chart using [helm-unittest](https://github.com/helm-unittest/helm-unittest).
+
+---
+
+### Prerequisites
+
+Install the Helm unittest plugin:
+
+```bash
+helm plugin install https://github.com/helm-unittest/helm-unittest
+```
+
+###  Running Unit Tests
+
+Run all unit tests in the chart folder (e.g., `./coredns`):
+
+```bash
+helm unittest ./coredns
+```
+
+To output results in **JUnit XML** format:
+
+```bash
+mkdir -p test-results
+helm unittest --strict \
+  --output-type JUnit \
+  --output-file test-results/helm-unittest-report.xml \
+  ./coredns
+```
+
+---
+
+### Debugging Helm Charts
+
+Render the chart templates with real values to debug:
+
+```bash
+helm template ./coredns  --debug
+```
+## YAML Intellisense in VS Code
+
+Add this line at the top of your unit test YAML files for schema validation and autocompletion in VS Code:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+```
+
+This improves YAML editing and error highlighting for test definitions.
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `coredns` deployment:

--- a/charts/coredns/tests/clusterrole-autoscaler_test.yaml
+++ b/charts/coredns/tests/clusterrole-autoscaler_test.yaml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test ClusterRole for autoscaler
+
+templates:
+  - templates/clusterrole-autoscaler.yaml
+
+tests:
+  - it: should render ClusterRole when autoscaler and rbac are enabled
+    set:
+      autoscaler:
+        enabled: true
+      rbac:
+        create: true
+      customLabels:
+        team: devops
+      customAnnotations:
+        note: autoscaler
+
+    asserts:
+      - hasDocuments:
+          count: 1
+
+      - isKind:
+          of: ClusterRole
+
+      - matchRegex:
+          path: metadata.name
+          pattern: ^.*-autoscaler$
+
+      - equal:
+          path: rules[0].resources
+          value: ["nodes"]
+
+      - equal:
+          path: metadata.labels.team
+          value: devops
+
+      - equal:
+          path: metadata.annotations.note
+          value: autoscaler
+
+  - it: should not render ClusterRole if autoscaler is disabled
+    set:
+      autoscaler:
+        enabled: false
+      rbac:
+        create: true
+
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render ClusterRole if rbac is disabled
+    set:
+      autoscaler:
+        enabled: true
+      rbac:
+        create: false
+
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/coredns/tests/clusterrole_test.yaml
+++ b/charts/coredns/tests/clusterrole_test.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: ClusterRole RBAC Test
+
+templates:
+  - templates/clusterrole.yaml
+
+set:
+  deployment:
+    enabled: true
+  rbac:
+    create: true
+    pspEnable: true
+    
+
+tests:
+  - it: should render ClusterRole with correct name and rules
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-coredns
+      - contains:
+          path: rules[0].resources
+          content: endpoints
+      - contains:
+          path: rules[0].resources
+          content: services
+      - contains:
+          path: rules[0].resources
+          content: pods
+      - contains:
+          path: rules[0].resources
+          content: namespaces
+
+      - equal:
+          path: rules[1].apiGroups[0]
+          value: discovery.k8s.io
+      - contains:
+          path: rules[1].resources
+          content: endpointslices
+      - equal:
+          path: rules[2].apiGroups[0]
+          value: policy
+      - equal:
+          path: rules[2].apiGroups[1]
+          value: extensions
+      - contains:
+          path: rules[2].resources
+          content: podsecuritypolicies
+      - contains:
+          path: rules[2].verbs
+          content: use

--- a/charts/coredns/tests/clusterrolebinding_autoscaler_test.yaml
+++ b/charts/coredns/tests/clusterrolebinding_autoscaler_test.yaml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: ClusterRoleBinding Autoscaler Test
+
+templates:
+  - templates/clusterrolebinding-autoscaler.yaml
+
+set:
+  autoscaler:
+    enabled: true
+  rbac:
+    create: true
+  customLabels:
+    my-custom-label: "enabled"
+  customAnnotations:
+    custom-annotation: "test-value"
+
+release:
+  namespace: test-namespace
+
+tests:
+  - it: should render ClusterRoleBinding with correct metadata and subject
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-coredns-autoscaler
+
+      - equal:
+          path: metadata.labels.my-custom-label
+          value: enabled
+
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: test-value
+
+      - equal:
+          path: roleRef.apiGroup
+          value: rbac.authorization.k8s.io
+
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+
+      - equal:
+          path: roleRef.name
+          value: RELEASE-NAME-coredns-autoscaler
+
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+
+      - equal:
+          path: subjects[0].name
+          value: RELEASE-NAME-coredns-autoscaler
+
+      - equal:
+          path: subjects[0].namespace
+          value: test-namespace

--- a/charts/coredns/tests/clusterrolebinding_test.yaml
+++ b/charts/coredns/tests/clusterrolebinding_test.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: ClusterRoleBinding Test
+
+templates:
+  - templates/clusterrolebinding.yaml
+
+set:
+  deployment:
+    enabled: true
+  rbac:
+    create: true
+
+  nameOverride: coredns-test
+  serviceAccount:
+    name: coredns-test
+
+release:
+  namespace: test-namespace
+
+tests:
+  - it: should render ClusterRoleBinding with correct metadata and subjects
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-coredns-test
+
+      - equal:
+          path: roleRef.apiGroup
+          value: rbac.authorization.k8s.io
+
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+
+      - equal:
+          path: roleRef.name
+          value: RELEASE-NAME-coredns-test
+
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+
+      - equal:
+          path: subjects[0].name
+          value: coredns-test
+
+      - equal:
+          path: subjects[0].namespace
+          value: test-namespace

--- a/charts/coredns/tests/configmap_autoscaler_test.yaml
+++ b/charts/coredns/tests/configmap_autoscaler_test.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: ConfigMap Autoscaler Test
+
+templates:
+  - templates/configmap-autoscaler.yaml
+
+set:
+  autoscaler:
+    enabled: true
+    coresPerReplica: 256
+    nodesPerReplica: 32
+    preventSinglePointFailure: true
+    min: 1
+    max: 10
+    includeUnschedulableNodes: false
+    configmap:
+      annotations:
+        autoscaler-note: "used by cluster-autoscaler"
+  customLabels:
+    my-custom-label: "enabled"
+  customAnnotations:
+    custom-annotation: "test-value"
+
+release:
+  namespace: test-namespace
+
+tests:
+  - it: should render ConfigMap with correct metadata and autoscaler values
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-coredns-autoscaler
+
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+
+      - equal:
+          path: metadata.labels.my-custom-label
+          value: enabled
+
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: test-value
+
+      - equal:
+          path: metadata.annotations.autoscaler-note
+          value: used by cluster-autoscaler
+
+      - matchRegex:
+          path: data.linear
+          pattern: '"coresPerReplica": 256'
+
+      - matchRegex:
+          path: data.linear
+          pattern: '"nodesPerReplica": 32'
+
+      - matchRegex:
+          path: data.linear
+          pattern: '"preventSinglePointFailure": true'
+
+      - matchRegex:
+          path: data.linear
+          pattern: '"min": 1'
+
+      - matchRegex:
+          path: data.linear
+          pattern: '"max": 10'
+
+      - matchRegex:
+          path: data.linear
+          pattern: '"includeUnschedulableNodes": false'

--- a/charts/coredns/tests/configmap_test.yaml
+++ b/charts/coredns/tests/configmap_test.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: "Test coredns configmap generation"
+templates:
+  - templates/configmap.yaml
+
+tests:
+  - it: "should create a configmap with custom Corefile and zone files"
+    set:
+      deployment:
+        enabled: true
+        skipConfig: false
+      customAnnotations:
+        custom-annotation: "test-value"
+      servers:
+        - zones:
+            - zone: "example.com"
+              scheme: "."
+          port: 5353
+          plugins:
+            - name: forward
+              parameters: ". 8.8.8.8"
+      zoneFiles:
+        - filename: db.example.com
+          contents: |
+            example.com.  IN  A  192.0.2.1
+
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.Corefile
+          pattern: "example\\.com:5353 \\{"
+      - matchRegex:
+          path: data.Corefile
+          pattern: "forward \\. 8\\.8\\.8\\.8"
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: "test-value"
+      - matchRegex:
+          path: 'data["db.example.com"]'
+          pattern: "example\\.com\\.\\s+IN\\s+A\\s+192\\.0\\.2\\.1"

--- a/charts/coredns/tests/deployment-autoscaler_test.yaml
+++ b/charts/coredns/tests/deployment-autoscaler_test.yaml
@@ -1,0 +1,77 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test autoscaler deployment
+templates:
+  - templates/configmap-autoscaler.yaml
+  - templates/deployment-autoscaler.yaml
+
+tests:
+  - it: should render autoscaler deployment with correct image
+    set:
+      autoscaler:
+        enabled: true
+        image:
+          repository: autoscaler
+          tag: v1.0.0
+          pullPolicy: IfNotPresent
+      hpa:
+        enabled: false
+    template: templates/deployment-autoscaler.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-coredns-autoscaler
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: autoscaler:v1.0.0
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: should set correct priorityClassName and tolerations
+    set:
+      autoscaler:
+        enabled: true
+        priorityClassName: system-cluster-critical
+        tolerations:
+          - key: "CriticalAddonsOnly"
+            operator: "Exists"
+        image:
+          repository: autoscaler
+          tag: v1.0.0
+      hpa:
+        enabled: false
+    template: templates/deployment-autoscaler.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: system-cluster-critical
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: CriticalAddonsOnly
+      - equal:
+          path: spec.template.spec.tolerations[0].operator
+          value: Exists
+
+  - it: should not render deployment if autoscaler disabled
+    set:
+      autoscaler:
+        enabled: false
+      hpa:
+        enabled: false
+    template: templates/deployment-autoscaler.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render deployment if hpa enabled
+    set:
+      autoscaler:
+        enabled: true
+      hpa:
+        enabled: true
+    template: templates/deployment-autoscaler.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/coredns/tests/deployment_test.yaml
+++ b/charts/coredns/tests/deployment_test.yaml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: CoreDNS Deployment Tests
+templates:
+  - templates/configmap.yaml
+  - templates/deployment.yaml
+
+tests:
+  - it: should render a deployment with the correct image
+    set:
+      deployment:
+        enabled: true
+      image:
+        repository: coredns/coredns
+        tag: 1.10.1
+    documentIndex: 0
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: coredns/coredns:1.10.1
+
+  - it: should include tolerations when isClusterService is true
+    set:
+      deployment:
+        enabled: true
+      isClusterService: true
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+    documentIndex: 0
+    template: templates/deployment.yaml
+    asserts:
+      - exists:
+          path: spec.template.spec.tolerations
+
+  - it: should contain checksum/config annotation
+    set:
+      deployment:
+        enabled: true
+    documentIndex: 0
+    template: templates/deployment.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations.checksum/config
+          pattern: ^[a-f0-9]{64}$
+
+  - it: should set pod security context and priority class
+    set:
+      deployment:
+        enabled: true
+      podSecurityContext:
+        runAsUser: 1000
+      priorityClassName: system-cluster-critical
+    documentIndex: 0
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: system-cluster-critical

--- a/charts/coredns/tests/hpa_test.yaml
+++ b/charts/coredns/tests/hpa_test.yaml
@@ -1,0 +1,110 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: HPA Test
+
+templates:
+  - templates/hpa.yaml
+
+set:
+  hpa:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 5
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 300
+        policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
+  deployment:
+    name: coredns
+  customLabels:
+    custom-label: "true"
+  customAnnotations:
+    custom-annotation: "enabled"
+  autoscaler:
+    enabled: false
+
+release:
+  namespace: test-namespace
+
+tests:
+  - it: should render HPA with correct metadata and spec
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-coredns
+
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+
+      - equal:
+          path: metadata.labels.custom-label
+          value: "true"
+
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: "enabled"
+
+      - equal:
+          path: spec.minReplicas
+          value: 1
+
+      - equal:
+          path: spec.maxReplicas
+          value: 5
+
+      - equal:
+          path: spec.scaleTargetRef.apiVersion
+          value: apps/v1
+
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: coredns
+
+      - equal:
+          path: spec.metrics[0].type
+          value: Resource
+
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: cpu
+
+      - equal:
+          path: spec.metrics[0].resource.target.type
+          value: Utilization
+
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 80
+
+      - equal:
+          path: spec.behavior.scaleUp.stabilizationWindowSeconds
+          value: 300
+
+      - equal:
+          path: spec.behavior.scaleUp.policies[0].type
+          value: Percent
+
+      - equal:
+          path: spec.behavior.scaleUp.policies[0].value
+          value: 100
+
+      - equal:
+          path: spec.behavior.scaleUp.policies[0].periodSeconds
+          value: 15

--- a/charts/coredns/tests/poddisruptionbudget_test.yaml
+++ b/charts/coredns/tests/poddisruptionbudget_test.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: PodDisruptionBudget Test
+
+templates:
+  - templates/poddisruptionbudget.yaml
+
+set:
+  deployment:
+    enabled: true
+
+  isClusterService: true
+
+  podDisruptionBudget:
+    maxUnavailable: 1
+
+  customLabels:
+    my-custom-label: "enabled"
+
+  customAnnotations:
+    custom-annotation: "true"
+
+release:
+  namespace: test-namespace
+
+tests:
+  - it: should render PodDisruptionBudget with correct metadata and spec
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-coredns
+
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+
+      - equal:
+          path: metadata.labels.my-custom-label
+          value: enabled
+
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: "true"
+
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: coredns
+
+      - equal:
+          path: spec.selector.matchLabels["k8s-app"]
+          value: coredns

--- a/charts/coredns/tests/service-metrics_test.yaml
+++ b/charts/coredns/tests/service-metrics_test.yaml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Prometheus Metrics Service Test
+
+templates:
+  - templates/service-metrics.yaml
+
+set:
+  deployment:
+    enabled: true
+
+  prometheus:
+    service:
+      enabled: true
+      annotations:
+        prometheus.io/scrape: "true"
+      selector:
+        app: custom-coredns
+
+  service:
+    annotations:
+      monitoring: "enabled"
+
+  customLabels:
+    my-custom-label: "true"
+
+  customAnnotations:
+    custom-annotation: "true"
+  isClusterService: true
+
+release:
+  namespace: test-namespace
+
+tests:
+  - it: should render Prometheus metrics Service with correct metadata and port
+    asserts:
+      - isKind:
+          of: Service
+
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-coredns-metrics
+
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: metrics
+
+      - equal:
+          path: metadata.labels["my-custom-label"]
+          value: "true"
+
+      - equal:
+          path: metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+      - equal:
+          path: metadata.annotations["monitoring"]
+          value: "enabled"
+
+      - equal:
+          path: metadata.annotations["custom-annotation"]
+          value: "true"
+
+      - equal:
+          path: spec.selector.app
+          value: custom-coredns
+
+      - equal:
+          path: spec.ports[0].name
+          value: metrics
+
+      - equal:
+          path: spec.ports[0].port
+          value: 9153
+
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 9153

--- a/charts/coredns/tests/service_test.yaml
+++ b/charts/coredns/tests/service_test.yaml
@@ -1,0 +1,108 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Service Rendering Test
+
+templates:
+  - templates/service.yaml
+
+set:
+  deployment:
+    enabled: true
+
+  service:
+    name: "custom-service-name"
+    annotations:
+      service-annotation: "value"
+    selector:
+      component: "dns"
+    clusterIP: "10.96.0.10"
+    clusterIPs:
+      - "10.96.0.10"
+      - "fd00::10"
+    externalIPs:
+      - "1.2.3.4"
+    externalTrafficPolicy: "Local"
+    loadBalancerIP: "4.3.2.1"
+    loadBalancerClass: "my-lb-class"
+    ipFamilyPolicy: "PreferDualStack"
+    trafficDistribution: "Topology"
+
+  customLabels:
+    my-custom-label: "enabled"
+
+  customAnnotations:
+    custom-annotation: "test"
+
+  isClusterService: true
+
+release:
+  namespace: test-ns
+
+tests:
+  - it: should render a valid Service with custom values
+    asserts:
+      - isKind:
+          of: Service
+
+      - equal:
+          path: metadata.name
+          value: custom-service-name
+
+      - equal:
+          path: metadata.namespace
+          value: test-ns
+
+      - equal:
+          path: metadata.labels.my-custom-label
+          value: enabled
+
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: test
+
+      - equal:
+          path: metadata.annotations.service-annotation
+          value: value
+
+      - equal:
+          path: spec.selector.component
+          value: dns
+
+      - equal:
+          path: spec.clusterIP
+          value: 10.96.0.10
+
+      - equal:
+          path: spec.clusterIPs[0]
+          value: 10.96.0.10
+
+      - equal:
+          path: spec.clusterIPs[1]
+          value: fd00::10
+
+      - equal:
+          path: spec.externalIPs[0]
+          value: 1.2.3.4
+
+      - equal:
+          path: spec.externalTrafficPolicy
+          value: Local
+
+      - equal:
+          path: spec.loadBalancerIP
+          value: 4.3.2.1
+
+      - equal:
+          path: spec.loadBalancerClass
+          value: my-lb-class
+
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+
+      - equal:
+          path: spec.trafficDistribution
+          value: Topology

--- a/charts/coredns/tests/serviceaccount_autoscaler_test.yaml
+++ b/charts/coredns/tests/serviceaccount_autoscaler_test.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Autoscaler ServiceAccount Test
+
+templates:
+  - templates/serviceaccount-autoscaler.yaml
+
+set:
+  autoscaler:
+    enabled: true
+    image:
+      pullSecrets:
+        - name: my-registry-secret
+  rbac:
+    create: true
+  customLabels:
+    my-custom-label: "true"
+  customAnnotations:
+    custom-annotation: "enabled"
+
+release:
+  name: release-name
+  namespace: test-namespace
+
+tests:
+  - it: should render ServiceAccount with correct name, namespace, labels, annotations, and pullSecrets
+    asserts:
+      - isKind:
+          of: ServiceAccount
+
+      - equal:
+          path: metadata.name
+          value: release-name-coredns-autoscaler
+
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+
+      - equal:
+          path: metadata.labels.my-custom-label
+          value: "true"
+
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: "enabled"
+
+      - equal:
+          path: imagePullSecrets[0].name
+          value: my-registry-secret

--- a/charts/coredns/tests/serviceaccount_test.yaml
+++ b/charts/coredns/tests/serviceaccount_test.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: ServiceAccount Test
+
+templates:
+  - templates/serviceaccount.yaml
+
+set:
+  deployment:
+    enabled: true
+  serviceAccount:
+    create: true
+    annotations:
+      serviceaccount-annotation: "true"
+  customAnnotations:
+    custom-annotation: "yes"
+  image:
+    pullSecrets:
+      - name: my-pull-secret
+
+release:
+  namespace: test-namespace
+  name: test-release
+
+tests:
+  - it: should render ServiceAccount with correct name, annotations, and pullSecrets
+    asserts:
+      - isKind:
+          of: ServiceAccount
+
+      - equal:
+          path: metadata.name
+          value: test-release-coredns
+
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: yes
+
+      - equal:
+          path: metadata.annotations.serviceaccount-annotation
+          value: "true"
+
+      - equal:
+          path: imagePullSecrets[0].name
+          value: my-pull-secret

--- a/charts/coredns/tests/servicemonitor_test.yaml
+++ b/charts/coredns/tests/servicemonitor_test.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: ServiceMonitor Rendering Test
+
+templates:
+  - templates/servicemonitor.yaml
+
+set:
+  deployment:
+    enabled: true
+  prometheus:
+    monitor:
+      enabled: true
+      namespace: monitoring
+      interval: 15s
+      additionalLabels:
+        team: infra
+      selector:
+        matchLabels:
+          my-custom-label: "true"
+  customAnnotations:
+    monitoring: "enabled"
+  isClusterService: true
+
+release:
+  name: test-release
+  namespace: default
+
+tests:
+  - it: should render ServiceMonitor with correct metadata and selector
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+
+      - equal:
+          path: metadata.name
+          value: test-release-coredns
+
+      - equal:
+          path: metadata.namespace
+          value: monitoring
+
+      - equal:
+          path: metadata.labels.team
+          value: infra
+
+      - equal:
+          path: metadata.annotations.monitoring
+          value: "enabled"
+
+      - equal:
+          path: spec.namespaceSelector.matchNames[0]
+          value: default
+
+      - equal:
+          path: spec.selector.matchLabels.my-custom-label
+          value: "true"
+
+      - equal:
+          path: spec.endpoints[0].port
+          value: metrics
+
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 15s


### PR DESCRIPTION


#### Why is this pull request needed and what does it do?
  - Added unit tests for ClusterRole, ClusterRoleBinding, ConfigMap, Deployment, HPA, PDB, Service, ServiceMonitor, and ServiceAccount
  - Included autoscaler-specific test files
  - Updated GitHub Actions workflow to run chart testing
  
#### Which issues (if any) are related?
fix #208 


Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

