### PR TITLE
fix(deps): update cpa/cluster-proportional-autoscaler to v1.9.0

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.40.0
+version: 1.41.0
 appVersion: 1.12.0
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -19,5 +19,5 @@ maintainers:
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: add https:// to tcp-only scheme list
+    - kind: changed
+      description: bump cluster-proportional-autoscaler to v1.9.0

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -341,7 +341,7 @@ autoscaler:
 
   image:
     repository: registry.k8s.io/cpa/cluster-proportional-autoscaler
-    tag: "1.8.5"
+    tag: "v1.9.0"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
#### Why is this pull request needed and what does it do?

Update cpa/cluster-proportional-autoscaler to v1.9.0

Changelogs:
- https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/releases/tag/1.8.6
- https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/releases/tag/v1.8.8
- https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/releases/tag/v1.8.9
- https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/releases/tag/v1.9.0

Diff:
- https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/compare/1.8.5...v1.9.0

#### Which issues (if any) are related?

N/A

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.