### PR TITLE
Fix default ports for dns:// scheme [rebased]

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.42.0
+version: 1.42.1
 appVersion: 1.12.0
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -19,5 +19,5 @@ maintainers:
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Added Helm unit tests for CoreDNS chart components
+    - kind: removed
+      description: Removed "istcp" true for default dns:// scheme

--- a/charts/coredns/templates/_helpers.tpl
+++ b/charts/coredns/templates/_helpers.tpl
@@ -99,10 +99,9 @@ Generate the list of ports automatically from the server definitions
             {{- end -}}
         {{- end -}}
 
-        {{/* If none of the zones specify scheme, default to dns:// on both tcp & udp */}}
+        {{/* If none of the zones specify scheme, default to dns:// udp */}}
         {{- if and (not (index $innerdict "istcp")) (not (index $innerdict "isudp")) -}}
             {{- $innerdict := set $innerdict "isudp" true -}}
-            {{- $innerdict := set $innerdict "istcp" true -}}
         {{- end -}}
 
         {{- if .nodePort -}}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?
This pull request is duplicate of [PR 23](https://github.com/coredns/helm/pull/23). Since original PR 23 contributor @k0da does not respond on request to rebase and bump chart version, I decided to create additional PR.

> According to [values.yaml](https://github.com/coredns/helm/blob/master/charts/coredns/values.yaml#L148)
> dns:// is supposed to be udp only with optional tcp enablement through
> use_tcp flag.

#### Which issues (if any) are related?
Related to [PR 23](https://github.com/coredns/helm/pull/23)

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

