### PR TITLE
Default udp fix

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.42.3
+version: 1.42.4
 appVersion: 1.12.2
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -19,5 +19,5 @@ maintainers:
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Upgrade CoreDNS to 1.12.2
+    - kind: fixed
+      description: Fix service port removal if `scheme` is not defined.

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -20,4 +20,4 @@ type: application
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fix service port removal if `scheme` is not defined.
+      description: Fix service port removal if `scheme` is not defined, and enable use_tcp for default configuration.

--- a/charts/coredns/templates/_helpers.tpl
+++ b/charts/coredns/templates/_helpers.tpl
@@ -86,7 +86,7 @@ Generate the list of ports automatically from the server definitions
         TCP: tls://, grpc://, https://
         */}}
         {{- range .zones -}}
-            {{- if has (default "" .scheme) (list "dns://") -}}
+            {{- if has (default "" .scheme) (list "dns://" "") -}}
                 {{/* Optionally enable tcp for this service as well */}}
                 {{- if eq (default false .use_tcp) true }}
                     {{- $innerdict := set $innerdict "istcp" true -}}
@@ -157,7 +157,7 @@ Generate the list of ports automatically from the server definitions
         TCP: tls://, grpc://, https://
         */}}
         {{- range .zones -}}
-            {{- if has (default "" .scheme) (list "dns://") -}}
+            {{- if has (default "" .scheme) (list "dns://" "") -}}
                 {{/* Optionally enable tcp for this service as well */}}
                 {{- if eq (default false .use_tcp) true }}
                     {{- $innerdict := set $innerdict "istcp" true -}}

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -107,6 +107,7 @@ securityContext:
 servers:
 - zones:
   - zone: .
+    use_tcp: true
   port: 53
   # -- expose the service on a different port
   # servicePort: 5353


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?
Undefined `scheme` defaults to `scheme: dns://`, and tcp port enabled by default with `use_tcp: true` in [values.yaml](https://github.com/coredns/helm/blob/master/charts/coredns/values.yaml)
#### Which issues (if any) are related?
Related to [212](https://github.com/coredns/helm/issues/212)

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

