### PR TITLE
Quote service IPs to prevent YAML misinterpretation

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.45.2
+version: 1.45.3
 appVersion: 1.13.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -19,5 +19,5 @@ maintainers:
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Add configurable dnsPolicy for deployment
+    - kind: fixed
+      description: Fixed YAML parsing of IPv6 service IPs by quoting them

--- a/charts/coredns/templates/service.yaml
+++ b/charts/coredns/templates/service.yaml
@@ -30,21 +30,21 @@ spec:
     app.kubernetes.io/name: {{ template "coredns.name" . }}
     {{- end }}
   {{- if .Values.service.clusterIP }}
-  clusterIP: {{ .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP | quote }}
   {{- end }}
   {{- if .Values.service.clusterIPs }}
   clusterIPs:
-  {{ toYaml .Values.service.clusterIPs | nindent 4 }}
+  {{ toJson .Values.service.clusterIPs | nindent 4 }}
   {{- end }}
   {{- if .Values.service.externalIPs }}
   externalIPs:
-  {{- toYaml .Values.service.externalIPs | nindent 4 }}
+  {{- toJson .Values.service.externalIPs | nindent 4 }}
   {{- end }}
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   {{- if .Values.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}
   {{- end }}
   {{- if .Values.service.loadBalancerClass }}
   loadBalancerClass: {{ .Values.service.loadBalancerClass }}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->
#### Why is this pull request needed and what does it do?

IPv6 in YAML needs to be quoted because certain IPs can cause misinterpretations.

One example is an IP ending in a colon, ex: `fd::` as YAML thinks it's a new key.

Additionally, I replaced toYaml with toJson on the IP lists. I don't think lists are as problematic, but I figured there might be some edge-case and it's safer to just ensure they're properly quoted. It could be replaced with a range loop and print each IP manually with quotes, but toJson is simpler and still compliant.

#### Which issues (if any) are related?

None

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).

Changes are automatically published when merged to `main`. They are not published on branches.

<details>
  <summary>Note on DCO</summary>

  If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

