### PR TITLE
fix: allow for ipv6 address for prometheus

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.46.0
+version: 1.46.1
 appVersion: 1.13.1
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -19,5 +19,5 @@ maintainers:
 type: application
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Add scrapeTimeout, scheme, honorLabels, tlsConfig, relabelings, and metricRelabelings options to ServiceMonitor endpoint
+    - kind: fixed
+      description: Chart will no longer fail to render if ipv6 address is used in prometheus plugin parameters

--- a/charts/coredns/templates/_helpers.tpl
+++ b/charts/coredns/templates/_helpers.tpl
@@ -187,7 +187,7 @@ Generate the list of ports automatically from the server definitions
             {{- if eq .name "prometheus" -}}
                 {{- $prometheus_addr := toString .parameters -}}
                 {{- $prometheus_addr_list := regexSplit ":" $prometheus_addr -1 -}}
-                {{- $prometheus_port := index $prometheus_addr_list 1 -}}
+                {{- $prometheus_port := last $prometheus_addr_list }}
                 {{- $ports := set $ports $prometheus_port (dict "istcp" true "isudp" false) -}}
             {{- end -}}
         {{- end -}}


### PR DESCRIPTION
#### Why is this pull request needed and what does it do?
if you set prometheus parameters from and ipv4 address "0.0.0.0:91543" to a ipv6 address "[::]:91543" the template will fail to render.
Currently the port generation code is assuming the second value in the split is the port which will work on ipv4 but wont work on ipv6 addresses.
The code now picks the last colon split in the list which should always be the port and will work for both ipv4 and ipv6.

What would be better instead of string splitting would be to use the sprig urlParse function
example:
```
            {{- if eq .name "prometheus" -}}
                {{- $prometheus_params := toString .parameters -}}
		{{- $prometheus_url := urlParse $prometheus_params -}}
                {{- $ports := set $ports $prometheus_url.port (dict "istcp" true "isudp" false) -}}
            {{- end -}}
```

but this function is also broken for ipv6 it seems.

Checklist:

* [x] I have bumped the chart version according to [versioning](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#versioning).
* [x] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#changelog).
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by [DCO](https://github.com/coredns/helm/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).
