### PR TITLE
Allow separate labels and selector for the autoscaler

### DIFF
--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: coredns
-version: 1.47.0
+version: 1.47.1
 appVersion: 1.14.6
 home: https://coredns.io
 icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
@@ -18,6 +18,6 @@ maintainers:
   - name: shubham-cmyk
 type: application
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: Bump to CoreDNS 1.14.6
+    artifacthub.io/changes: |
+    - kind: added
+      description: Allow separate labels and selector for the cluster-proportional-autoscaler Deployment

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -18,6 +18,6 @@ maintainers:
   - name: shubham-cmyk
 type: application
 annotations:
-    artifacthub.io/changes: |
+  artifacthub.io/changes: |
     - kind: added
       description: Allow separate labels and selector for the cluster-proportional-autoscaler Deployment

--- a/charts/coredns/README.md
+++ b/charts/coredns/README.md
@@ -172,7 +172,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraVolumeMounts`                            | Optional array of volumes to mount inside the CoreDNS container                                                                           | []                                                           |
 | `extraSecrets`                                 | Optional array of secrets to mount inside the CoreDNS container                                                                           | []                                                           |
 | `env`                                          | Optional array of environment variables for CoreDNS container                                                                             | []                                                           |
-| `customLabels`                                 | Optional labels for Deployment(s), Pod, Service, ServiceMonitor objects                                                                   | {}                                                           |
+| `customLabels`                                 | Optional labels for Deployment, Pod, Service, ServiceMonitor. Also applied to the autoscaler when `autoscaler.inheritCustomLabels` is true | {}                                                           |
 | `customAnnotations`                            | Optional annotations for Deployment(s), Pod, Service, ServiceMonitor objects                                                              |
 | `rollingUpdate.maxUnavailable`                 | Maximum number of unavailable replicas during rolling update                                                                              | `1`                                                          |
 | `rollingUpdate.maxSurge`                       | Maximum number of pods created above desired number of pods                                                                               | `25%`                                                        |
@@ -214,7 +214,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | `autoscaler.livenessProbe.timeoutSeconds`      | When the probe times out                                                                                                                  | `5`                                                          |
 | `autoscaler.livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.                                                | `3`                                                          |
 | `autoscaler.livenessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.                                              | `1`                                                          |
-| `autoscaler.extraContainers`                   | Optional array of sidecar containers                                                                                                      | []                                                           |
+| `autoscaler.extraContainers`                   | Optional array of sidecar containers                                                                                                      | []
+| `autoscaler.inheritCustomLabels`               | Also apply top-level `customLabels` to the autoscaler Deployment and pods                                                                 | `true`                                                       |
+| `autoscaler.customLabels`                      | Extra labels for the autoscaler Deployment and pods                                                                                       | {}                                                           |
+| `autoscaler.podLabels`                         | Extra labels for autoscaler pods only                                                                                                     | {}                                                           |
+| `autoscaler.selector`                          | Optional pod selector override for the autoscaler Deployment. Pod labels must match if set                                                | {}                                                           |
 | `deployment.enabled`                           | Optionally disable the main deployment and its respective resources.                                                                      | `true`                                                       |
 | `deployment.name`                              | Name of the deployment if `deployment.enabled` is true. Otherwise the name of an existing deployment for the autoscaler or HPA to target. | `""`                                                         |
 | `deployment.annotations`                       | Annotations to add to the main deployment                                                                                                 | `{}`                                                         |
@@ -261,6 +265,12 @@ will be deployed. This will default to a coredns replica for every 256 cores, or
 and `autoscaler.nodesPerReplica`. When cluster is using large nodes (with more
 cores), `coresPerReplica` should dominate. If using small nodes,
 `nodesPerReplica` should dominate.
+
+To give the autoscaler different labels than CoreDNS (for example when `customLabels`
+includes `k8s-app: kube-dns`), set `autoscaler.inheritCustomLabels: false` and put
+autoscaler-only labels in `autoscaler.customLabels` / `autoscaler.podLabels`.
+If you set `autoscaler.selector`, those matchLabels must also exist on the autoscaler
+pod template.
 
 This also creates a ServiceAccount, ClusterRole, and ClusterRoleBinding for
 the autoscaler deployment.

--- a/charts/coredns/templates/_helpers.tpl
+++ b/charts/coredns/templates/_helpers.tpl
@@ -54,6 +54,30 @@ app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
 {{- end -}}
 
 {{/*
+Extra labels for autoscaler resources.
+Inherits top-level customLabels when autoscaler.inheritCustomLabels is true,
+then applies autoscaler.customLabels (overrides on key conflicts).
+*/}}
+{{- define "coredns.autoscaler.extraLabels" -}}
+{{- $labels := dict -}}
+{{- if .Values.autoscaler.inheritCustomLabels -}}
+{{- range $k, $v := (default dict .Values.customLabels) -}}
+{{- $_ := set $labels $k $v -}}
+{{- end -}}
+{{- end -}}
+{{- range $k, $v := (default dict .Values.autoscaler.customLabels) -}}
+{{- $_ := set $labels $k $v -}}
+{{- end -}}
+{{- if $labels -}}
+{{- toYaml $labels -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Allow k8s-app label to be overridden
+*/}}
+
+{{/*
 Allow k8s-app label to be overridden
 */}}
 {{- define "coredns.k8sapplabel" -}}

--- a/charts/coredns/templates/clusterrole-autoscaler.yaml
+++ b/charts/coredns/templates/clusterrole-autoscaler.yaml
@@ -5,8 +5,8 @@ kind: ClusterRole
 metadata:
   name: {{ template "coredns.fullname" . }}-autoscaler
   labels: {{- include "coredns.labels.autoscaler" . | nindent 4 }}
-{{- if .Values.customLabels }}
-{{ toYaml .Values.customLabels | indent 4 }}
+{{- with (include "coredns.autoscaler.extraLabels" . | trim) }}
+{{ . | indent 4 }}
 {{- end }}
 {{- with .Values.customAnnotations }}
   annotations:

--- a/charts/coredns/templates/clusterrolebinding-autoscaler.yaml
+++ b/charts/coredns/templates/clusterrolebinding-autoscaler.yaml
@@ -5,8 +5,8 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "coredns.fullname" . }}-autoscaler
   labels: {{- include "coredns.labels.autoscaler" . | nindent 4 }}
-{{- if .Values.customLabels }}
-{{ toYaml .Values.customLabels | indent 4 }}
+{{- with (include "coredns.autoscaler.extraLabels" . | trim) }}
+{{ . | indent 4 }}
 {{- end }}
 {{- with .Values.customAnnotations }}
   annotations:

--- a/charts/coredns/templates/configmap-autoscaler.yaml
+++ b/charts/coredns/templates/configmap-autoscaler.yaml
@@ -6,8 +6,8 @@ metadata:
   name: {{ template "coredns.fullname" . }}-autoscaler
   namespace:  {{ .Release.Namespace }}
   labels: {{- include "coredns.labels.autoscaler" . | nindent 4 }}
-    {{- if .Values.customLabels }}
-    {{- toYaml .Values.customLabels | nindent 4 }}
+    {{- with (include "coredns.autoscaler.extraLabels" . | trim) }}
+    {{- . | nindent 4 }}
     {{- end }}
   {{- if or .Values.autoscaler.configmap.annotations .Values.customAnnotations }}
   annotations:

--- a/charts/coredns/templates/deployment-autoscaler.yaml
+++ b/charts/coredns/templates/deployment-autoscaler.yaml
@@ -1,7 +1,12 @@
 {{- if and (.Values.autoscaler.enabled) (not .Values.hpa.enabled) }}
 {{- $asExtraLabels := dict }}
 {{- if .Values.autoscaler.inheritCustomLabels }}
-{{- $asExtraLabels = merge $asExtraLabels (default dict .Values.customLabels) }}
+{{- range $k, $v := (default dict .Values.customLabels) }}
+{{- $_ := set $asExtraLabels $k $v }}
+{{- end }}
+{{- end }}
+{{- range $k, $v := (default dict .Values.autoscaler.customLabels) }}
+{{- $_ := set $asExtraLabels $k $v }}
 {{- end }}
 {{- $asExtraLabels = merge $asExtraLabels (default dict .Values.autoscaler.customLabels) }}
 ---

--- a/charts/coredns/templates/deployment-autoscaler.yaml
+++ b/charts/coredns/templates/deployment-autoscaler.yaml
@@ -1,4 +1,9 @@
 {{- if and (.Values.autoscaler.enabled) (not .Values.hpa.enabled) }}
+{{- $asExtraLabels := dict }}
+{{- if .Values.autoscaler.inheritCustomLabels }}
+{{- $asExtraLabels = merge $asExtraLabels (default dict .Values.customLabels) }}
+{{- end }}
+{{- $asExtraLabels = merge $asExtraLabels (default dict .Values.autoscaler.customLabels) }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -6,8 +11,8 @@ metadata:
   name: {{ template "coredns.fullname" . }}-autoscaler
   namespace: {{ .Release.Namespace }}
   labels: {{- include "coredns.labels.autoscaler" . | nindent 4 }}
-{{- if .Values.customLabels }}
-{{ toYaml .Values.customLabels | indent 4 }}
+{{- with $asExtraLabels }}
+{{ toYaml . | indent 4 }}
 {{- end }}
 {{- with .Values.customAnnotations }}
   annotations:
@@ -15,24 +20,31 @@ metadata:
 {{- end }}
 spec:
   selector:
+    {{- if .Values.autoscaler.selector }}
+    {{- toYaml .Values.autoscaler.selector | nindent 4 }}
+    {{- else }}
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name | quote }}
       {{- if .Values.isClusterService }}
       k8s-app: {{ template "coredns.k8sapplabel" . }}-autoscaler
       {{- end }}
       app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+    {{- end }}
   template:
     metadata:
       labels:
         {{- if .Values.isClusterService }}
-        {{- if not (hasKey .Values.customLabels "k8s-app")}}
+        {{- if not (hasKey $asExtraLabels "k8s-app") }}
         k8s-app: {{ template "coredns.k8sapplabel" . }}-autoscaler
         {{- end }}
         {{- end }}
         app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        {{- if .Values.customLabels }}
-        {{ toYaml .Values.customLabels | nindent 8 }}
+        {{- with $asExtraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.autoscaler.podLabels }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap-autoscaler.yaml") . | sha256sum }}

--- a/charts/coredns/templates/serviceaccount-autoscaler.yaml
+++ b/charts/coredns/templates/serviceaccount-autoscaler.yaml
@@ -6,8 +6,8 @@ metadata:
   name: {{ template "coredns.fullname" . }}-autoscaler
   namespace: {{ .Release.Namespace }}
   labels: {{- include "coredns.labels.autoscaler" . | nindent 4 }}
-{{- if .Values.customLabels }}
-{{ toYaml .Values.customLabels | indent 4 }}
+{{- with (include "coredns.autoscaler.extraLabels" . | trim) }}
+{{ . | indent 4 }}
 {{- end }}
 {{- with .Values.customAnnotations }}
   annotations:

--- a/charts/coredns/tests/deployment-autoscaler_test.yaml
+++ b/charts/coredns/tests/deployment-autoscaler_test.yaml
@@ -117,10 +117,10 @@ tests:
           path: spec.template.metadata.labels.k8s-app
           value: coredns-autoscaler
       - equal:
-          path: spec.selector.matchLabels.app\.kubernetes\.io/name
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
           value: coredns-autoscaler
       - equal:
-          path: spec.selector.matchLabels.app\.kubernetes\.io/instance
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
           value: RELEASE-NAME
 
   - it: should not copy customLabels k8s-app onto autoscaler when inheritCustomLabels is false

--- a/charts/coredns/tests/deployment-autoscaler_test.yaml
+++ b/charts/coredns/tests/deployment-autoscaler_test.yaml
@@ -94,3 +94,128 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: false
+
+  
+  - it: should still apply customLabels to autoscaler when inheritCustomLabels is true
+    set:
+      isClusterService: true
+      customLabels:
+        team: dns
+      autoscaler:
+        enabled: true
+      hpa:
+        enabled: false
+    template: templates/deployment-autoscaler.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: dns
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: dns
+      - equal:
+          path: spec.template.metadata.labels.k8s-app
+          value: coredns-autoscaler
+      - equal:
+          path: spec.selector.matchLabels.app\.kubernetes\.io/name
+          value: coredns-autoscaler
+      - equal:
+          path: spec.selector.matchLabels.app\.kubernetes\.io/instance
+          value: RELEASE-NAME
+
+  - it: should not copy customLabels k8s-app onto autoscaler when inheritCustomLabels is false
+    set:
+      isClusterService: true
+      customLabels:
+        k8s-app: kube-dns
+      autoscaler:
+        enabled: true
+        inheritCustomLabels: false
+      hpa:
+        enabled: false
+    template: templates/deployment-autoscaler.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.k8s-app
+          value: coredns-autoscaler
+      - notEqual:
+          path: spec.template.metadata.labels.k8s-app
+          value: kube-dns
+      - equal:
+          path: metadata.labels.k8s-app
+          value: coredns-autoscaler
+
+  - it: should use autoscaler customLabels and podLabels instead of shared customLabels
+    set:
+      customLabels:
+        team: dns
+      autoscaler:
+        enabled: true
+        inheritCustomLabels: false
+        customLabels:
+          team: autoscaler
+        podLabels:
+          role: scaler
+      hpa:
+        enabled: false
+    template: templates/deployment-autoscaler.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: autoscaler
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: autoscaler
+      - equal:
+          path: spec.template.metadata.labels.role
+          value: scaler
+      - notExists:
+          path: metadata.labels.role
+
+  - it: should allow overriding the autoscaler selector
+    set:
+      autoscaler:
+        enabled: true
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: coredns-autoscaler
+            app.kubernetes.io/instance: RELEASE-NAME
+            component: autoscaler
+        podLabels:
+          component: autoscaler
+      hpa:
+        enabled: false
+    template: templates/deployment-autoscaler.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels.component
+          value: autoscaler
+      - equal:
+          path: spec.template.metadata.labels.component
+          value: autoscaler
+
+  - it: should merge inherited customLabels with autoscaler customLabels
+    set:
+      customLabels:
+        team: dns
+      autoscaler:
+        enabled: true
+        inheritCustomLabels: true
+        customLabels:
+          owner: platform
+      hpa:
+        enabled: false
+    template: templates/deployment-autoscaler.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: dns
+      - equal:
+          path: metadata.labels.owner
+          value: platform
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: dns
+      - equal:
+          path: spec.template.metadata.labels.owner
+          value: platform

--- a/charts/coredns/tests/deployment_test.yaml
+++ b/charts/coredns/tests/deployment_test.yaml
@@ -60,3 +60,18 @@ tests:
       - equal:
           path: spec.template.spec.priorityClassName
           value: system-cluster-critical
+
+  - it: should still apply customLabels to the main CoreDNS deployment
+    set:
+      deployment:
+        enabled: true
+      customLabels:
+        team: dns
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: dns
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: dns

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -287,7 +287,8 @@ env: []
 # See https://github.com/coredns/helm/blob/master/charts/coredns/README.md#adopting-existing-coredns-resources
 # k8sAppLabelOverride: "kube-dns"
 
-# Custom labels to apply to Deployment, Pod, Configmap, Service, ServiceMonitor. Including autoscaler if enabled.
+# Custom labels to apply to Deployment, Pod, Configmap, Service, ServiceMonitor.
+# Also applied to the autoscaler when autoscaler.inheritCustomLabels is true.
 customLabels: {}
 
 # Custom annotations to apply to Deployment, Pod, Configmap, Service, ServiceMonitor. Including autoscaler if enabled.
@@ -342,6 +343,17 @@ autoscaler:
 
   # Annotations for the coredns proportional autoscaler pods
   podAnnotations: {}
+
+  # When true, top-level customLabels are also applied to the autoscaler Deployment/pods.
+  inheritCustomLabels: true
+  # Extra labels for the autoscaler Deployment and pods. Independent of customLabels
+  # when inheritCustomLabels is false.
+  customLabels: {}
+  # Extra labels applied only to autoscaler pods.
+  podLabels: {}
+  # Optional pod selector override for the autoscaler Deployment.
+  # If set, pod template labels must match this selector.
+  selector: {}
 
   podSecurityContext: {}
   securityContext:


### PR DESCRIPTION
#### Why is this pull request needed and what does it do?

customLabels was applied to both the CoreDNS Deployment and the
cluster-proportional-autoscaler Deployment. Selector-like keys such as
k8s-app: kube-dns could land on autoscaler pods.

This adds optional autoscaler.customLabels, autoscaler.podLabels,
autoscaler.selector, and autoscaler.inheritCustomLabels (default true).
Default output is unchanged.

#### Which issues (if any) are related?

Fixes #179

Checklist:
* [x] I have bumped the chart version according to versioning.
* [x] I have updated the chart changelog with all the changes that come with this pull request according to changelog.
* [x] Any new values are backwards compatible and/or have sensible default.
* [x] I have signed off all my commits as required by DCO.